### PR TITLE
Fix 'Caught unhandled unknown exception; terminating' bug in SQL steps

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -313,13 +313,15 @@ int DBconn::ExecuteVoid(const wxString &query)
 
 wxString DBconn::GetLastError()
 {
+	size_t len = lastError.length();
+
 	// Return the last error message, minus any trailing line ends
-	if (lastError.substr(lastError.length() - 2, 2) == wxT("\r\n")) // DOS
-		return lastError.substr(0, lastError.length() - 2);
-	else if (lastError.substr(lastError.length() - 1, 1) == wxT("\n")) // Unix
-		return lastError.substr(0, lastError.length() - 1);
-	else if (lastError.substr(lastError.length() - 1, 1) == wxT("\r")) // Mac
-		return lastError.substr(0, lastError.length() - 1);
+	if (len >= 2 && lastError.substr(len - 2, 2) == wxT("\r\n")) // DOS
+		return lastError.substr(0, len - 2);
+	else if (len >= 1 && lastError.substr(len - 1, 1) == wxT("\n")) // Unix
+		return lastError.substr(0, len - 1);
+	else if (len >= 1 && lastError.substr(len - 1, 1) == wxT("\r")) // Mac
+		return lastError.substr(0, len - 1);
 	else
 		return lastError;
 }


### PR DESCRIPTION
Running pgagent on Debian jessie with an SQL jobstep crashes the worker thread with the error message `Caught unhandled unknown exception; terminating`. Both job and jobstep status then remain as `r` (running) until the pgagent process quits. After restarting pgagent, which cleans up the job status and sets it to `d` (aborted), the job containing the SQL jobstep is free to run again, but the next run will end up in the same deadlock situation.

I have tracked down the problem to `DBconn::GetLastError()`, which gets called after each SQL jobstep execution in `Job::Execute()`: there, `DBconn::GetLastError()` throws an exception whenever the last error message is empty.

This pull request fixes this problem by adding missing bounds checks to `DBconn::GetLastError()`.

Here is a log of pgagent with an SQL jobstep:

    $ pgagent -l 2 -f hostaddr=127.0.0.1 port=5432 dbname=pgdb user=pgdb  
    DEBUG: Creating primary connection
    DEBUG: Connection Information:
    DEBUG:      user         : pgdb
    DEBUG:      port         : 5432
    DEBUG:      host         : 127.0.0.1
    DEBUG:      dbname       : pgdb
    DEBUG:      password     : 
    DEBUG:      conn timeout : 0
    DEBUG: Connection Information:
    DEBUG:      user         : pgdb
    DEBUG:      port         : 5432
    DEBUG:      host         : 127.0.0.1
    DEBUG:      dbname       : pgdb
    DEBUG:      password     : 
    DEBUG:      conn timeout : 0
    DEBUG: Creating DB connection: user=pgdb port=5432 hostaddr=127.0.0.1 dbname=pgdb
    DEBUG: Database sanity check
    DEBUG: Clearing zombies
    DEBUG: Checking for jobs to run
    DEBUG: Sleeping...
    DEBUG: Clearing inactive connections
    DEBUG: Connection stats: total - 1, free - 0, deleted - 0
    DEBUG: Checking for jobs to run
    DEBUG: Sleeping...
    [...]
    DEBUG: Clearing inactive connections
    DEBUG: Connection stats: total - 1, free - 0, deleted - 0
    DEBUG: Checking for jobs to run
    DEBUG: Sleeping...
    DEBUG: Connection stats: total - 1, free - 0, deleted - 0
    DEBUG: Checking for jobs to run
    DEBUG: Creating job thread for job 5
    DEBUG: Creating DB connection: user=pgdb port=5432 hostaddr=127.0.0.1 dbname=pgdb
    DEBUG: Allocating new connection to database pgdb
    DEBUG: Starting job: 5
    DEBUG: Sleeping...
    DEBUG: Creating DB connection: user=pgdb port=5432 hostaddr=127.0.0.1 dbname=pgdb dbname=pgdb
    DEBUG: Allocating new connection to database pgdb
    DEBUG: Executing SQL step 40 (part of job 5)
    *** Caught unhandled unknown exception; terminating
    DEBUG: Destroying job thread for job 5
    DEBUG: Checking for jobs to run
    DEBUG: Sleeping...
    DEBUG: Clearing inactive connections
    DEBUG: Connection stats: total - 3, free - 0, deleted - 0
    DEBUG: Checking for jobs to run
    DEBUG: Sleeping...
    DEBUG: Clearing inactive connections
    DEBUG: Connection stats: total - 3, free - 0, deleted - 0
    DEBUG: Checking for jobs to run
    DEBUG: Sleeping...
    [...]
