### PR TITLE
Update pgAgent.cpp

### DIFF
--- a/pgAgent.cpp
+++ b/pgAgent.cpp
@@ -90,6 +90,9 @@ int MainRestartLoop(DBconn *serviceConn)
 	wxString hostname = wxGetFullHostName();
 
 	rc = serviceConn->ExecuteVoid(
+	         wxT("DELETE FROM pgagent.pga_jobagent WHERE jagpid in (SELECT pg_backend_pid())"));
+	
+	rc = serviceConn->ExecuteVoid(
 	         wxT("INSERT INTO pgagent.pga_jobagent (jagpid, jagstation) SELECT pg_backend_pid(), '") + hostname + wxT("'"));
 	if (rc < 0)
 		return rc;


### PR DESCRIPTION
I had some trouble when running Pgagent in a container. Every time the container was restarted Pgagent would fail with the following error:

> WARNING: Couldn't create the primary connection (attempt 1): ERROR:  duplicate key value violates unique constraint "pga_jobagent_pkey"
> DETAIL:  Key (jagpid)=(1504) already exists.

This patch removes any preexisting rows in pga_jobagent with identical jagpid. 