### PR TITLE
Use FindBoost.cmake and 2 other cmake files from cmake 3.30.4 to work with boost version 1.69.0

### DIFF
--- a/cmake/FindBoost.cmake
+++ b/cmake/FindBoost.cmake
@@ -1,245 +1,582 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 
-#.rst:
-# FindBoost
-# ---------
-#
-# Find Boost include dirs and libraries
-#
-# Use this module by invoking find_package with the form::
-#
-#   find_package(Boost
-#     [version] [EXACT]      # Minimum or EXACT version e.g. 1.67.0
-#     [REQUIRED]             # Fail with error if Boost is not found
-#     [COMPONENTS <libs>...] # Boost libraries by their canonical name
-#                            # e.g. "date_time" for "libboost_date_time"
-#     [OPTIONAL_COMPONENTS <libs>...]
-#                            # Optional Boost libraries by their canonical name)
-#     )                      # e.g. "date_time" for "libboost_date_time"
-#
-# This module finds headers and requested component libraries OR a CMake
-# package configuration file provided by a "Boost CMake" build.  For the
-# latter case skip to the "Boost CMake" section below.  For the former
-# case results are reported in variables::
-#
-#   Boost_FOUND            - True if headers and requested libraries were found
-#   Boost_INCLUDE_DIRS     - Boost include directories
-#   Boost_LIBRARY_DIRS     - Link directories for Boost libraries
-#   Boost_LIBRARIES        - Boost component libraries to be linked
-#   Boost_<C>_FOUND        - True if component <C> was found (<C> is upper-case)
-#   Boost_<C>_LIBRARY      - Libraries to link for component <C> (may include
-#                            target_link_libraries debug/optimized keywords)
-#   Boost_VERSION          - BOOST_VERSION value from boost/version.hpp
-#   Boost_LIB_VERSION      - Version string appended to library filenames
-#   Boost_MAJOR_VERSION    - Boost major version number (X in X.y.z)
-#   Boost_MINOR_VERSION    - Boost minor version number (Y in x.Y.z)
-#   Boost_SUBMINOR_VERSION - Boost subminor version number (Z in x.y.Z)
-#   Boost_LIB_DIAGNOSTIC_DEFINITIONS (Windows)
-#                          - Pass to add_definitions() to have diagnostic
-#                            information about Boost's automatic linking
-#                            displayed during compilation
-#
-# Note that Boost Python components require a Python version suffix
-# (Boost 1.67 and later), e.g. ``python36`` or ``python27`` for the
-# versions built against Python 3.6 and 2.7, respectively.  This also
-# applies to additional components using Python including
-# ``mpi_python`` and ``numpy``.  Earlier Boost releases may use
-# distribution-specific suffixes such as ``2``, ``3`` or ``2.7``.
-# These may also be used as suffixes, but note that they are not
-# portable.
-#
-# This module reads hints about search locations from variables::
-#
-#   BOOST_ROOT             - Preferred installation prefix
-#    (or BOOSTROOT)
-#   BOOST_INCLUDEDIR       - Preferred include directory e.g. <prefix>/include
-#   BOOST_LIBRARYDIR       - Preferred library directory e.g. <prefix>/lib
-#   Boost_NO_SYSTEM_PATHS  - Set to ON to disable searching in locations not
-#                            specified by these hint variables. Default is OFF.
-#   Boost_ADDITIONAL_VERSIONS
-#                          - List of Boost versions not known to this module
-#                            (Boost install locations may contain the version)
-#
-# and saves search results persistently in CMake cache entries::
-#
-#   Boost_INCLUDE_DIR         - Directory containing Boost headers
-#   Boost_LIBRARY_DIR_RELEASE - Directory containing release Boost libraries
-#   Boost_LIBRARY_DIR_DEBUG   - Directory containing debug Boost libraries
-#   Boost_<C>_LIBRARY_DEBUG   - Component <C> library debug variant
-#   Boost_<C>_LIBRARY_RELEASE - Component <C> library release variant
-#
-# The following :prop_tgt:`IMPORTED` targets are also defined::
-#
-#   Boost::boost                  - Target for header-only dependencies
-#                                   (Boost include directory)
-#   Boost::<C>                    - Target for specific component dependency
-#                                   (shared or static library); <C> is lower-
-#                                   case
-#   Boost::diagnostic_definitions - interface target to enable diagnostic
-#                                   information about Boost's automatic linking
-#                                   during compilation (adds BOOST_LIB_DIAGNOSTIC)
-#   Boost::disable_autolinking    - interface target to disable automatic
-#                                   linking with MSVC (adds BOOST_ALL_NO_LIB)
-#   Boost::dynamic_linking        - interface target to enable dynamic linking
-#                                   linking with MSVC (adds BOOST_ALL_DYN_LINK)
-#
-# Implicit dependencies such as Boost::filesystem requiring
-# Boost::system will be automatically detected and satisfied, even
-# if system is not specified when using find_package and if
-# Boost::system is not added to target_link_libraries.  If using
-# Boost::thread, then Threads::Threads will also be added automatically.
-#
-# It is important to note that the imported targets behave differently
-# than variables created by this module: multiple calls to
-# find_package(Boost) in the same directory or sub-directories with
-# different options (e.g. static or shared) will not override the
-# values of the targets created by the first call.
-#
-# Users may set these hints or results as cache entries.  Projects
-# should not read these entries directly but instead use the above
-# result variables.  Note that some hint names start in upper-case
-# "BOOST".  One may specify these as environment variables if they are
-# not specified as CMake variables or cache entries.
-#
-# This module first searches for the Boost header files using the above
-# hint variables (excluding BOOST_LIBRARYDIR) and saves the result in
-# Boost_INCLUDE_DIR.  Then it searches for requested component libraries
-# using the above hints (excluding BOOST_INCLUDEDIR and
-# Boost_ADDITIONAL_VERSIONS), "lib" directories near Boost_INCLUDE_DIR,
-# and the library name configuration settings below.  It saves the
-# library directories in Boost_LIBRARY_DIR_DEBUG and
-# Boost_LIBRARY_DIR_RELEASE and individual library
-# locations in Boost_<C>_LIBRARY_DEBUG and Boost_<C>_LIBRARY_RELEASE.
-# When one changes settings used by previous searches in the same build
-# tree (excluding environment variables) this module discards previous
-# search results affected by the changes and searches again.
-#
-# Boost libraries come in many variants encoded in their file name.
-# Users or projects may tell this module which variant to find by
-# setting variables::
-#
-#   Boost_USE_DEBUG_LIBS     - Set to ON or OFF to specify whether to search
-#                              and use the debug libraries.  Default is ON.
-#   Boost_USE_RELEASE_LIBS   - Set to ON or OFF to specify whether to search
-#                              and use the release libraries.  Default is ON.
-#   Boost_USE_MULTITHREADED  - Set to OFF to use the non-multithreaded
-#                              libraries ('mt' tag).  Default is ON.
-#   Boost_USE_STATIC_LIBS    - Set to ON to force the use of the static
-#                              libraries.  Default is OFF.
-#   Boost_USE_STATIC_RUNTIME - Set to ON or OFF to specify whether to use
-#                              libraries linked statically to the C++ runtime
-#                              ('s' tag).  Default is platform dependent.
-#   Boost_USE_DEBUG_RUNTIME  - Set to ON or OFF to specify whether to use
-#                              libraries linked to the MS debug C++ runtime
-#                              ('g' tag).  Default is ON.
-#   Boost_USE_DEBUG_PYTHON   - Set to ON to use libraries compiled with a
-#                              debug Python build ('y' tag). Default is OFF.
-#   Boost_USE_STLPORT        - Set to ON to use libraries compiled with
-#                              STLPort ('p' tag).  Default is OFF.
-#   Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS
-#                            - Set to ON to use libraries compiled with
-#                              STLPort deprecated "native iostreams"
-#                              ('n' tag).  Default is OFF.
-#   Boost_COMPILER           - Set to the compiler-specific library suffix
-#                              (e.g. "-gcc43").  Default is auto-computed
-#                              for the C++ compiler in use.  A list may be
-#                              used if multiple compatible suffixes should
-#                              be tested for, in decreasing order of
-#                              preference.
-#   Boost_THREADAPI          - Suffix for "thread" component library name,
-#                              such as "pthread" or "win32".  Names with
-#                              and without this suffix will both be tried.
-#   Boost_NAMESPACE          - Alternate namespace used to build boost with
-#                              e.g. if set to "myboost", will search for
-#                              myboost_thread instead of boost_thread.
-#
-# Other variables one may set to control this module are::
-#
-#   Boost_DEBUG              - Set to ON to enable debug output from FindBoost.
-#                              Please enable this before filing any bug report.
-#   Boost_DETAILED_FAILURE_MSG
-#                            - Set to ON to add detailed information to the
-#                              failure message even when the REQUIRED option
-#                              is not given to the find_package call.
-#   Boost_REALPATH           - Set to ON to resolve symlinks for discovered
-#                              libraries to assist with packaging.  For example,
-#                              the "system" component library may be resolved to
-#                              "/usr/lib/libboost_system.so.1.67.0" instead of
-#                              "/usr/lib/libboost_system.so".  This does not
-#                              affect linking and should not be enabled unless
-#                              the user needs this information.
-#   Boost_LIBRARY_DIR        - Default value for Boost_LIBRARY_DIR_RELEASE and
-#                              Boost_LIBRARY_DIR_DEBUG.
-#
-# On Visual Studio and Borland compilers Boost headers request automatic
-# linking to corresponding libraries.  This requires matching libraries
-# to be linked explicitly or available in the link library search path.
-# In this case setting Boost_USE_STATIC_LIBS to OFF may not achieve
-# dynamic linking.  Boost automatic linking typically requests static
-# libraries with a few exceptions (such as Boost.Python).  Use::
-#
-#   add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
-#
-# to ask Boost to report information about automatic linking requests.
-#
-# Example to find Boost headers only::
-#
-#   find_package(Boost 1.36.0)
-#   if(Boost_FOUND)
-#     include_directories(${Boost_INCLUDE_DIRS})
-#     add_executable(foo foo.cc)
-#   endif()
-#
-# Example to find Boost libraries and use imported targets::
-#
-#   find_package(Boost 1.56 REQUIRED COMPONENTS
-#                date_time filesystem iostreams)
-#   add_executable(foo foo.cc)
-#   target_link_libraries(foo Boost::date_time Boost::filesystem
-#                             Boost::iostreams)
-#
-# Example to find Boost Python 3.6 libraries and use imported targets::
-#
-#   find_package(Boost 1.67 REQUIRED COMPONENTS
-#                python36 numpy36)
-#   add_executable(foo foo.cc)
-#   target_link_libraries(foo Boost::python36 Boost::numpy36)
-#
-# Example to find Boost headers and some *static* (release only) libraries::
-#
-#   set(Boost_USE_STATIC_LIBS        ON)  # only find static libs
-#   set(Boost_USE_DEBUG_LIBS         OFF) # ignore debug libs and
-#   set(Boost_USE_RELEASE_LIBS       ON)  # only find release libs
-#   set(Boost_USE_MULTITHREADED      ON)
-#   set(Boost_USE_STATIC_RUNTIME    OFF)
-#   find_package(Boost 1.66.0 COMPONENTS date_time filesystem system ...)
-#   if(Boost_FOUND)
-#     include_directories(${Boost_INCLUDE_DIRS})
-#     add_executable(foo foo.cc)
-#     target_link_libraries(foo ${Boost_LIBRARIES})
-#   endif()
-#
-# Boost CMake
-# ^^^^^^^^^^^
-#
-# If Boost was built using the boost-cmake project it provides a package
-# configuration file for use with find_package's Config mode.  This
-# module looks for the package configuration file called
-# BoostConfig.cmake or boost-config.cmake and stores the result in cache
-# entry "Boost_DIR".  If found, the package configuration file is loaded
-# and this module returns with no further action.  See documentation of
-# the Boost CMake package configuration for details on what it provides.
-#
-# Set Boost_NO_BOOST_CMAKE to ON to disable the search for boost-cmake.
+#[=======================================================================[.rst:
+FindBoost
+---------
+
+.. versionchanged:: 3.30
+  This module is available only if policy :policy:`CMP0167` is not set to
+  ``NEW``.  Port projects to upstream Boost's ``BoostConfig.cmake`` package
+  configuration file, for which ``find_package(Boost)`` now searches.
+
+Find Boost include dirs and libraries
+
+Use this module by invoking :command:`find_package` with the form:
+
+.. code-block:: cmake
+
+  find_package(Boost
+    [version] [EXACT]      # Minimum or EXACT version e.g. 1.67.0
+    [REQUIRED]             # Fail with error if Boost is not found
+    [COMPONENTS <libs>...] # Boost libraries by their canonical name
+                           # e.g. "date_time" for "libboost_date_time"
+    [OPTIONAL_COMPONENTS <libs>...]
+                           # Optional Boost libraries by their canonical name)
+    )                      # e.g. "date_time" for "libboost_date_time"
+
+This module finds headers and requested component libraries OR a CMake
+package configuration file provided by a "Boost CMake" build.  For the
+latter case skip to the :ref:`Boost CMake` section below.
+
+.. versionadded:: 3.7
+  ``bzip2`` and ``zlib`` components (Windows only).
+
+.. versionadded:: 3.11
+  The ``OPTIONAL_COMPONENTS`` option.
+
+.. versionadded:: 3.13
+  ``stacktrace_*`` components.
+
+.. versionadded:: 3.19
+  ``bzip2`` and ``zlib`` components on all platforms.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``Boost_FOUND``
+  True if headers and requested libraries were found.
+
+``Boost_INCLUDE_DIRS``
+  Boost include directories.
+
+``Boost_LIBRARY_DIRS``
+  Link directories for Boost libraries.
+
+``Boost_LIBRARIES``
+  Boost component libraries to be linked.
+
+``Boost_<COMPONENT>_FOUND``
+  True if component ``<COMPONENT>`` was found (``<COMPONENT>`` name is upper-case).
+
+``Boost_<COMPONENT>_LIBRARY``
+  Libraries to link for component ``<COMPONENT>`` (may include
+  :command:`target_link_libraries` debug/optimized keywords).
+
+``Boost_VERSION_MACRO``
+  ``BOOST_VERSION`` value from ``boost/version.hpp``.
+
+``Boost_VERSION_STRING``
+  Boost version number in ``X.Y.Z`` format.
+
+``Boost_VERSION``
+  Boost version number in ``X.Y.Z`` format (same as ``Boost_VERSION_STRING``).
+
+  .. versionchanged:: 3.15
+    In previous CMake versions, this variable used the raw version string
+    from the Boost header (same as ``Boost_VERSION_MACRO``).
+    See policy :policy:`CMP0093`.
+
+``Boost_LIB_VERSION``
+  Version string appended to library filenames.
+
+``Boost_VERSION_MAJOR``, ``Boost_MAJOR_VERSION``
+  Boost major version number (``X`` in ``X.Y.Z``).
+
+``Boost_VERSION_MINOR``, ``Boost_MINOR_VERSION``
+  Boost minor version number (``Y`` in ``X.Y.Z``).
+
+``Boost_VERSION_PATCH``, ``Boost_SUBMINOR_VERSION``
+  Boost subminor version number (``Z`` in ``X.Y.Z``).
+
+``Boost_VERSION_COUNT``
+  Amount of version components (3).
+
+``Boost_LIB_DIAGNOSTIC_DEFINITIONS`` (Windows-specific)
+  Pass to :command:`add_definitions` to have diagnostic
+  information about Boost's automatic linking
+  displayed during compilation
+
+.. versionadded:: 3.15
+  The ``Boost_VERSION_<PART>`` variables.
+
+Cache variables
+^^^^^^^^^^^^^^^
+
+Search results are saved persistently in CMake cache entries:
+
+``Boost_INCLUDE_DIR``
+  Directory containing Boost headers.
+
+``Boost_LIBRARY_DIR_RELEASE``
+  Directory containing release Boost libraries.
+
+``Boost_LIBRARY_DIR_DEBUG``
+  Directory containing debug Boost libraries.
+
+``Boost_<COMPONENT>_LIBRARY_DEBUG``
+  Component ``<COMPONENT>`` library debug variant.
+
+``Boost_<COMPONENT>_LIBRARY_RELEASE``
+  Component ``<COMPONENT>`` library release variant.
+
+.. versionadded:: 3.3
+  Per-configuration variables ``Boost_LIBRARY_DIR_RELEASE`` and
+  ``Boost_LIBRARY_DIR_DEBUG``.
+
+Hints
+^^^^^
+
+This module reads hints about search locations from variables:
+
+``BOOST_ROOT``, ``BOOSTROOT``
+  Preferred installation prefix.
+
+``BOOST_INCLUDEDIR``
+  Preferred include directory e.g. ``<prefix>/include``.
+
+``BOOST_LIBRARYDIR``
+  Preferred library directory e.g. ``<prefix>/lib``.
+
+``Boost_NO_SYSTEM_PATHS``
+  Set to ``ON`` to disable searching in locations not
+  specified by these hint variables. Default is ``OFF``.
+
+``Boost_ADDITIONAL_VERSIONS``
+  List of Boost versions not known to this module.
+  (Boost install locations may contain the version).
+
+Users may set these hints or results as ``CACHE`` entries.  Projects
+should not read these entries directly but instead use the above
+result variables.  Note that some hint names start in upper-case
+``BOOST``.  One may specify these as environment variables if they are
+not specified as CMake variables or cache entries.
+
+This module first searches for the Boost header files using the above
+hint variables (excluding ``BOOST_LIBRARYDIR``) and saves the result in
+``Boost_INCLUDE_DIR``.  Then it searches for requested component libraries
+using the above hints (excluding ``BOOST_INCLUDEDIR`` and
+``Boost_ADDITIONAL_VERSIONS``), "lib" directories near ``Boost_INCLUDE_DIR``,
+and the library name configuration settings below.  It saves the
+library directories in ``Boost_LIBRARY_DIR_DEBUG`` and
+``Boost_LIBRARY_DIR_RELEASE`` and individual library
+locations in ``Boost_<COMPONENT>_LIBRARY_DEBUG`` and ``Boost_<COMPONENT>_LIBRARY_RELEASE``.
+When one changes settings used by previous searches in the same build
+tree (excluding environment variables) this module discards previous
+search results affected by the changes and searches again.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+.. versionadded:: 3.5
+
+This module defines the following :prop_tgt:`IMPORTED` targets:
+
+``Boost::boost``
+  Target for header-only dependencies. (Boost include directory).
+
+``Boost::headers``
+  .. versionadded:: 3.15
+    Alias for ``Boost::boost``.
+
+``Boost::<component>``
+  Target for specific component dependency (shared or static library);
+  ``<component>`` name is lower-case.
+
+``Boost::diagnostic_definitions``
+  Interface target to enable diagnostic information about Boost's automatic
+  linking during compilation (adds ``-DBOOST_LIB_DIAGNOSTIC``).
+
+``Boost::disable_autolinking``
+  Interface target to disable automatic linking with MSVC
+  (adds ``-DBOOST_ALL_NO_LIB``).
+
+``Boost::dynamic_linking``
+  Interface target to enable dynamic linking with MSVC
+  (adds ``-DBOOST_ALL_DYN_LINK``).
+
+Implicit dependencies such as ``Boost::filesystem`` requiring
+``Boost::system`` will be automatically detected and satisfied, even
+if system is not specified when using :command:`find_package` and if
+``Boost::system`` is not added to :command:`target_link_libraries`.  If using
+``Boost::thread``, then ``Threads::Threads`` will also be added automatically.
+
+It is important to note that the imported targets behave differently
+than variables created by this module: multiple calls to
+:command:`find_package(Boost)` in the same directory or sub-directories with
+different options (e.g. static or shared) will not override the
+values of the targets created by the first call.
+
+Other Variables
+^^^^^^^^^^^^^^^
+
+Boost libraries come in many variants encoded in their file name.
+Users or projects may tell this module which variant to find by
+setting variables:
+
+``Boost_USE_DEBUG_LIBS``
+  .. versionadded:: 3.10
+
+  Set to ``ON`` or ``OFF`` to specify whether to search and use the debug
+  libraries.  Default is ``ON``.
+
+``Boost_USE_RELEASE_LIBS``
+  .. versionadded:: 3.10
+
+  Set to ``ON`` or ``OFF`` to specify whether to search and use the release
+  libraries.  Default is ``ON``.
+
+``Boost_USE_MULTITHREADED``
+  Set to OFF to use the non-multithreaded libraries ("mt" tag). Default is
+  ``ON``.
+
+``Boost_USE_STATIC_LIBS``
+  Set to ON to force the use of the static libraries.  Default is ``OFF``.
+
+``Boost_USE_STATIC_RUNTIME``
+  Set to ``ON`` or ``OFF`` to specify whether to use libraries linked
+  statically to the C++ runtime ("s" tag).  Default is platform dependent.
+
+``Boost_USE_DEBUG_RUNTIME``
+  Set to ``ON`` or ``OFF`` to specify whether to use libraries linked to the
+  MS debug C++ runtime ("g" tag).  Default is ``ON``.
+
+``Boost_USE_DEBUG_PYTHON``
+  Set to ``ON`` to use libraries compiled with a debug Python build ("y"
+  tag).  Default is ``OFF``.
+
+``Boost_USE_STLPORT``
+  Set to ``ON`` to use libraries compiled with STLPort ("p" tag). Default is
+  ``OFF``.
+
+``Boost_USE_STLPORT_DEPRECATED_NATIVE_IOSTREAMS``
+  Set to ON to use libraries compiled with STLPort deprecated "native
+  iostreams" ("n" tag).  Default is ``OFF``.
+
+``Boost_COMPILER``
+  Set to the compiler-specific library suffix (e.g. ``-gcc43``).  Default is
+  auto-computed for the C++ compiler in use.
+
+  .. versionchanged:: 3.9
+    A list may be used if multiple compatible suffixes should be tested for,
+    in decreasing order of preference.
+
+``Boost_LIB_PREFIX``
+  .. versionadded:: 3.18
+
+  Set to the platform-specific library name prefix (e.g. ``lib``) used by
+  Boost static libs.  This is needed only on platforms where CMake does not
+  know the prefix by default.
+
+``Boost_ARCHITECTURE``
+  .. versionadded:: 3.13
+
+  Set to the architecture-specific library suffix (e.g. ``-x64``).
+  Default is auto-computed for the C++ compiler in use.
+
+``Boost_THREADAPI``
+  Suffix for ``thread`` component library name, such as ``pthread`` or
+  ``win32``.  Names with and without this suffix will both be tried.
+
+``Boost_NAMESPACE``
+  Alternate namespace used to build boost with e.g. if set to ``myboost``,
+  will search for ``myboost_thread`` instead of ``boost_thread``.
+
+Other variables one may set to control this module are:
+
+``Boost_DEBUG``
+  Set to ``ON`` to enable debug output from ``FindBoost``.
+  Please enable this before filing any bug report.
+
+``Boost_REALPATH``
+  Set to ``ON`` to resolve symlinks for discovered libraries to assist with
+  packaging.  For example, the "system" component library may be resolved to
+  ``/usr/lib/libboost_system.so.1.67.0`` instead of
+  ``/usr/lib/libboost_system.so``.  This does not affect linking and should
+  not be enabled unless the user needs this information.
+
+``Boost_LIBRARY_DIR``
+  Default value for ``Boost_LIBRARY_DIR_RELEASE`` and
+  ``Boost_LIBRARY_DIR_DEBUG``.
+
+``Boost_NO_WARN_NEW_VERSIONS``
+  .. versionadded:: 3.20
+
+  Set to ``ON`` to suppress the warning about unknown dependencies for new
+  Boost versions.
+
+On Visual Studio and Borland compilers Boost headers request automatic
+linking to corresponding libraries.  This requires matching libraries
+to be linked explicitly or available in the link library search path.
+In this case setting ``Boost_USE_STATIC_LIBS`` to ``OFF`` may not achieve
+dynamic linking.  Boost automatic linking typically requests static
+libraries with a few exceptions (such as ``Boost.Python``).  Use:
+
+.. code-block:: cmake
+
+  add_definitions(${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
+
+to ask Boost to report information about automatic linking requests.
+
+Examples
+^^^^^^^^
+
+Find Boost headers only:
+
+.. code-block:: cmake
+
+  find_package(Boost 1.36.0)
+  if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIRS})
+    add_executable(foo foo.cc)
+  endif()
+
+Find Boost libraries and use imported targets:
+
+.. code-block:: cmake
+
+  find_package(Boost 1.56 REQUIRED COMPONENTS
+               date_time filesystem iostreams)
+  add_executable(foo foo.cc)
+  target_link_libraries(foo Boost::date_time Boost::filesystem
+                            Boost::iostreams)
+
+Find Boost Python 3.6 libraries and use imported targets:
+
+.. code-block:: cmake
+
+  find_package(Boost 1.67 REQUIRED COMPONENTS
+               python36 numpy36)
+  add_executable(foo foo.cc)
+  target_link_libraries(foo Boost::python36 Boost::numpy36)
+
+Find Boost headers and some *static* (release only) libraries:
+
+.. code-block:: cmake
+
+  set(Boost_USE_STATIC_LIBS        ON)  # only find static libs
+  set(Boost_USE_DEBUG_LIBS        OFF)  # ignore debug libs and
+  set(Boost_USE_RELEASE_LIBS       ON)  # only find release libs
+  set(Boost_USE_MULTITHREADED      ON)
+  set(Boost_USE_STATIC_RUNTIME    OFF)
+  find_package(Boost 1.66.0 COMPONENTS date_time filesystem system ...)
+  if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIRS})
+    add_executable(foo foo.cc)
+    target_link_libraries(foo ${Boost_LIBRARIES})
+  endif()
+
+.. _`Boost CMake`:
+
+Boost CMake
+^^^^^^^^^^^
+
+If Boost was built using the boost-cmake project or from Boost 1.70.0 on
+it provides a package configuration file for use with find_package's config mode.
+This module looks for the package configuration file called
+``BoostConfig.cmake`` or ``boost-config.cmake`` and stores the result in
+``CACHE`` entry ``Boost_DIR``.  If found, the package configuration file is loaded
+and this module returns with no further action.  See documentation of
+the Boost CMake package configuration for details on what it provides.
+
+Set ``Boost_NO_BOOST_CMAKE`` to ``ON``, to disable the search for boost-cmake.
+#]=======================================================================]
+
+cmake_policy(GET CMP0167 _FindBoost_CMP0167)
+if(_FindBoost_CMP0167 STREQUAL "NEW")
+  message(FATAL_ERROR "The FindBoost module has been removed by policy CMP0167.")
+endif()
+
+if(_FindBoost_testing)
+  set(_FindBoost_included TRUE)
+  return()
+endif()
+
+# The FPHSA helper provides standard way of reporting final search results to
+# the user including the version and component checks.
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
 
 # Save project's policies
 cmake_policy(PUSH)
 cmake_policy(SET CMP0057 NEW) # if IN_LIST
+cmake_policy(SET CMP0102 NEW) # if mark_as_advanced(non_cache_var)
+cmake_policy(SET CMP0159 NEW) # file(STRINGS) with REGEX updates CMAKE_MATCH_<n>
+
+function(_boost_get_existing_target component target_var)
+  set(names "${component}")
+  if(component MATCHES "^([a-z_]*)(python|numpy)([1-9])\\.?([0-9]+)?$")
+    # handle pythonXY and numpyXY versioned components and also python X.Y, mpi_python etc.
+    list(APPEND names
+      "${CMAKE_MATCH_1}${CMAKE_MATCH_2}" # python
+      "${CMAKE_MATCH_1}${CMAKE_MATCH_2}${CMAKE_MATCH_3}" # pythonX
+      "${CMAKE_MATCH_1}${CMAKE_MATCH_2}${CMAKE_MATCH_3}${CMAKE_MATCH_4}" #pythonXY
+    )
+  endif()
+  # https://github.com/boost-cmake/boost-cmake uses boost::file_system etc.
+  # So handle similar constructions of target names
+  string(TOLOWER "${component}" lower_component)
+  list(APPEND names "${lower_component}")
+  foreach(prefix Boost boost)
+    foreach(name IN LISTS names)
+      if(TARGET "${prefix}::${name}")
+        # The target may be an INTERFACE library that wraps around a single other
+        # target for compatibility.  Unwrap this layer so we can extract real info.
+        if("${name}" MATCHES "^(python|numpy|mpi_python)([1-9])([0-9]+)$")
+          set(name_nv "${CMAKE_MATCH_1}")
+          if(TARGET "${prefix}::${name_nv}")
+            get_property(type TARGET "${prefix}::${name}" PROPERTY TYPE)
+            if(type STREQUAL "INTERFACE_LIBRARY")
+              get_property(lib TARGET "${prefix}::${name}" PROPERTY INTERFACE_LINK_LIBRARIES)
+              if("${lib}" STREQUAL "${prefix}::${name_nv}")
+                set(${target_var} "${prefix}::${name_nv}" PARENT_SCOPE)
+                return()
+              endif()
+            endif()
+          endif()
+        endif()
+        set(${target_var} "${prefix}::${name}" PARENT_SCOPE)
+        return()
+      endif()
+    endforeach()
+  endforeach()
+  set(${target_var} "" PARENT_SCOPE)
+endfunction()
+
+function(_boost_get_canonical_target_name component target_var)
+  string(TOLOWER "${component}" component)
+  if(component MATCHES "^([a-z_]*)(python|numpy)([1-9])\\.?([0-9]+)?$")
+    # handle pythonXY and numpyXY versioned components and also python X.Y, mpi_python etc.
+    set(${target_var} "Boost::${CMAKE_MATCH_1}${CMAKE_MATCH_2}" PARENT_SCOPE)
+  else()
+    set(${target_var} "Boost::${component}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+macro(_boost_set_in_parent_scope name value)
+  # Set a variable in parent scope and make it visible in current scope
+  set(${name} "${value}" PARENT_SCOPE)
+  set(${name} "${value}")
+endmacro()
+
+macro(_boost_set_if_unset name value)
+  if(NOT ${name})
+    _boost_set_in_parent_scope(${name} "${value}")
+  endif()
+endmacro()
+
+macro(_boost_set_cache_if_unset name value)
+  if(NOT ${name})
+    set(${name} "${value}" CACHE STRING "" FORCE)
+  endif()
+endmacro()
+
+macro(_boost_append_include_dir target)
+  get_target_property(inc "${target}" INTERFACE_INCLUDE_DIRECTORIES)
+  if(inc)
+    list(APPEND include_dirs "${inc}")
+  endif()
+endmacro()
+
+function(_boost_set_legacy_variables_from_config)
+  # Set legacy variables for compatibility if not set
+  set(include_dirs "")
+  set(library_dirs "")
+  set(libraries "")
+  # Header targets Boost::headers or Boost::boost
+  foreach(comp headers boost)
+    _boost_get_existing_target(${comp} target)
+    if(target)
+      _boost_append_include_dir("${target}")
+    endif()
+  endforeach()
+  # Library targets
+  foreach(comp IN LISTS Boost_FIND_COMPONENTS)
+    string(TOUPPER ${comp} uppercomp)
+    # Overwrite if set
+    _boost_set_in_parent_scope(Boost_${uppercomp}_FOUND "${Boost_${comp}_FOUND}")
+    if(Boost_${comp}_FOUND)
+      _boost_get_existing_target(${comp} target)
+      if(NOT target)
+        if(Boost_DEBUG OR Boost_VERBOSE)
+          message(WARNING "Could not find imported target for required component '${comp}'. Legacy variables for this component might be missing. Refer to the documentation of your Boost installation for help on variables to use.")
+        endif()
+        continue()
+      endif()
+      _boost_append_include_dir("${target}")
+      _boost_set_if_unset(Boost_${uppercomp}_LIBRARY "${target}")
+      _boost_set_if_unset(Boost_${uppercomp}_LIBRARIES "${target}") # Very old legacy variable
+      list(APPEND libraries "${target}")
+      get_property(type TARGET "${target}" PROPERTY TYPE)
+      if(NOT type STREQUAL "INTERFACE_LIBRARY")
+        foreach(cfg RELEASE DEBUG)
+          get_target_property(lib ${target} IMPORTED_LOCATION_${cfg})
+          if(lib)
+            get_filename_component(lib_dir "${lib}" DIRECTORY)
+            list(APPEND library_dirs ${lib_dir})
+            _boost_set_cache_if_unset(Boost_${uppercomp}_LIBRARY_${cfg} "${lib}")
+          endif()
+        endforeach()
+      elseif(Boost_DEBUG OR Boost_VERBOSE)
+        # For projects using only the Boost::* targets this warning can be safely ignored.
+        message(WARNING "Imported target '${target}' for required component '${comp}' has no artifact. Legacy variables for this component might be missing. Refer to the documentation of your Boost installation for help on variables to use.")
+      endif()
+      _boost_get_canonical_target_name("${comp}" canonical_target)
+      if(NOT TARGET "${canonical_target}")
+        add_library("${canonical_target}" INTERFACE IMPORTED)
+        target_link_libraries("${canonical_target}" INTERFACE "${target}")
+      endif()
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES include_dirs)
+  list(REMOVE_DUPLICATES library_dirs)
+  _boost_set_if_unset(Boost_INCLUDE_DIRS "${include_dirs}")
+  _boost_set_if_unset(Boost_LIBRARY_DIRS "${library_dirs}")
+  _boost_set_if_unset(Boost_LIBRARIES "${libraries}")
+  _boost_set_if_unset(Boost_VERSION_STRING "${Boost_VERSION_MAJOR}.${Boost_VERSION_MINOR}.${Boost_VERSION_PATCH}")
+  find_path(Boost_INCLUDE_DIR
+    NAMES boost/version.hpp boost/config.hpp
+    HINTS ${Boost_INCLUDE_DIRS}
+    NO_DEFAULT_PATH
+  )
+  if(NOT Boost_VERSION_MACRO OR NOT Boost_LIB_VERSION)
+    set(version_file ${Boost_INCLUDE_DIR}/boost/version.hpp)
+    if(EXISTS "${version_file}")
+      file(STRINGS "${version_file}" contents REGEX "#define BOOST_(LIB_)?VERSION ")
+      if(contents MATCHES "#define BOOST_VERSION ([0-9]+)")
+        _boost_set_if_unset(Boost_VERSION_MACRO "${CMAKE_MATCH_1}")
+      endif()
+      if(contents MATCHES "#define BOOST_LIB_VERSION \"([0-9_]+)\"")
+        _boost_set_if_unset(Boost_LIB_VERSION "${CMAKE_MATCH_1}")
+      endif()
+    endif()
+  endif()
+  _boost_set_if_unset(Boost_MAJOR_VERSION ${Boost_VERSION_MAJOR})
+  _boost_set_if_unset(Boost_MINOR_VERSION ${Boost_VERSION_MINOR})
+  _boost_set_if_unset(Boost_SUBMINOR_VERSION ${Boost_VERSION_PATCH})
+  if(WIN32)
+    _boost_set_if_unset(Boost_LIB_DIAGNOSTIC_DEFINITIONS "-DBOOST_LIB_DIAGNOSTIC")
+  endif()
+  if(NOT TARGET Boost::headers)
+    add_library(Boost::headers INTERFACE IMPORTED)
+    target_include_directories(Boost::headers INTERFACE ${Boost_INCLUDE_DIRS})
+  endif()
+  # Legacy targets w/o functionality as all handled by defined targets
+  foreach(lib diagnostic_definitions disable_autolinking dynamic_linking)
+    if(NOT TARGET Boost::${lib})
+      add_library(Boost::${lib} INTERFACE IMPORTED)
+    endif()
+  endforeach()
+  if(NOT TARGET Boost::boost)
+    add_library(Boost::boost INTERFACE IMPORTED)
+    target_link_libraries(Boost::boost INTERFACE Boost::headers)
+  endif()
+endfunction()
 
 #-------------------------------------------------------------------------------
-# Before we go searching, check whether boost-cmake is available, unless the
-# user specifically asked NOT to search for boost-cmake.
+# Before we go searching, check whether a boost cmake package is available, unless
+# the user specifically asked NOT to search for one.
 #
 # If Boost_DIR is set, this behaves as any find_package call would. If not,
 # it looks at BOOST_ROOT and BOOSTROOT to find Boost.
@@ -255,19 +592,56 @@ if (NOT Boost_NO_BOOST_CMAKE)
     endif()
   endif()
 
+  set(_boost_FIND_PACKAGE_ARGS "")
+  if(Boost_NO_SYSTEM_PATHS)
+    list(APPEND _boost_FIND_PACKAGE_ARGS NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH)
+  endif()
+
   # Do the same find_package call but look specifically for the CMake version.
   # Note that args are passed in the Boost_FIND_xxxxx variables, so there is no
   # need to delegate them to this find_package call.
-  find_package(Boost QUIET NO_MODULE)
-  mark_as_advanced(Boost_DIR)
+  if(BOOST_ROOT AND NOT Boost_ROOT)
+    # Honor BOOST_ROOT by setting Boost_ROOT with CMP0074 NEW behavior.
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0074 NEW)
+    set(Boost_ROOT "${BOOST_ROOT}")
+    set(_Boost_ROOT_FOR_CONFIG 1)
+  endif()
+  find_package(Boost QUIET NO_MODULE ${_boost_FIND_PACKAGE_ARGS})
+  if(_Boost_ROOT_FOR_CONFIG)
+    unset(_Boost_ROOT_FOR_CONFIG)
+    unset(Boost_ROOT)
+    cmake_policy(POP)
+  endif()
+  if (DEFINED Boost_DIR)
+    mark_as_advanced(Boost_DIR)
+  endif ()
 
-  # If we found boost-cmake, then we're done.  Print out what we found.
+  # If we found a boost cmake package, then we're done. Print out what we found.
   # Otherwise let the rest of the module try to find it.
-  if (Boost_FOUND)
-    message(STATUS "Boost ${Boost_FIND_VERSION} found.")
-    if (Boost_FIND_COMPONENTS)
-      message(STATUS "Found Boost components:\n   ${Boost_FIND_COMPONENTS}")
+  if(Boost_FOUND)
+    # Convert component found variables to standard variables if required
+    # Necessary for legacy boost-cmake and 1.70 builtin BoostConfig
+    if(Boost_FIND_COMPONENTS)
+      # Ignore the meta-component "ALL", introduced by Boost 1.73
+      list(REMOVE_ITEM Boost_FIND_COMPONENTS "ALL")
+
+      foreach(_comp IN LISTS Boost_FIND_COMPONENTS)
+        if(DEFINED Boost_${_comp}_FOUND)
+          continue()
+        endif()
+        string(TOUPPER ${_comp} _uppercomp)
+        if(DEFINED Boost${_comp}_FOUND) # legacy boost-cmake project
+          set(Boost_${_comp}_FOUND ${Boost${_comp}_FOUND})
+        elseif(DEFINED Boost_${_uppercomp}_FOUND) # Boost 1.70
+          set(Boost_${_comp}_FOUND ${Boost_${_uppercomp}_FOUND})
+        endif()
+      endforeach()
     endif()
+
+    find_package_handle_standard_args(Boost HANDLE_COMPONENTS CONFIG_MODE)
+    _boost_set_legacy_variables_from_config()
+
     # Restore project's policies
     cmake_policy(POP)
     return()
@@ -278,6 +652,56 @@ endif()
 #-------------------------------------------------------------------------------
 #  FindBoost functions & macros
 #
+
+#
+# Print debug text if Boost_DEBUG is set.
+# Call example:
+# _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "debug message")
+#
+function(_Boost_DEBUG_PRINT file line text)
+  if(Boost_DEBUG)
+    message(STATUS "[ ${file}:${line} ] ${text}")
+  endif()
+endfunction()
+
+#
+# _Boost_DEBUG_PRINT_VAR(file line variable_name [ENVIRONMENT]
+#                        [SOURCE "short explanation of origin of var value"])
+#
+#   ENVIRONMENT - look up environment variable instead of CMake variable
+#
+# Print variable name and its value if Boost_DEBUG is set.
+# Call example:
+# _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" BOOST_ROOT)
+#
+function(_Boost_DEBUG_PRINT_VAR file line name)
+  if(Boost_DEBUG)
+    cmake_parse_arguments(_args "ENVIRONMENT" "SOURCE" "" ${ARGN})
+
+    unset(source)
+    if(_args_SOURCE)
+      set(source " (${_args_SOURCE})")
+    endif()
+
+    if(_args_ENVIRONMENT)
+      if(DEFINED ENV{${name}})
+        set(value "\"$ENV{${name}}\"")
+      else()
+        set(value "<unset>")
+      endif()
+      set(_name "ENV{${name}}")
+    else()
+      if(DEFINED "${name}")
+        set(value "\"${${name}}\"")
+      else()
+        set(value "<unset>")
+      endif()
+      set(_name "${name}")
+    endif()
+
+    _Boost_DEBUG_PRINT("${file}" "${line}" "${_name} = ${value}${source}")
+  endif()
+endfunction()
 
 ############################################
 #
@@ -396,25 +820,27 @@ macro(_Boost_FIND_LIBRARY var build_type)
   # If Boost_LIBRARY_DIR_[RELEASE,DEBUG] is known then search only there.
   if(Boost_LIBRARY_DIR_${build_type})
     set(_boost_LIBRARY_SEARCH_DIRS_${build_type} ${Boost_LIBRARY_DIR_${build_type}} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
-    if(Boost_DEBUG)
-      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-        " Boost_LIBRARY_DIR_${build_type} = ${Boost_LIBRARY_DIR_${build_type}}"
-        " _boost_LIBRARY_SEARCH_DIRS_${build_type} = ${_boost_LIBRARY_SEARCH_DIRS_${build_type}}")
-    endif()
+    _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                           "Boost_LIBRARY_DIR_${build_type}")
+    _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                           "_boost_LIBRARY_SEARCH_DIRS_${build_type}")
   endif()
 endmacro()
 
 #-------------------------------------------------------------------------------
 
-#
-# Runs compiler with "-dumpversion" and parses major/minor
-# version with a regex.
-#
-function(_Boost_COMPILER_DUMPVERSION _OUTPUT_VERSION)
-  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.[0-9]+)?" "\\1\\2"
-    _boost_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+# Convert CMAKE_CXX_COMPILER_VERSION to boost compiler suffix version.
+function(_Boost_COMPILER_DUMPVERSION _OUTPUT_VERSION _OUTPUT_VERSION_MAJOR _OUTPUT_VERSION_MINOR)
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.[0-9]+)?" "\\1"
+    _boost_COMPILER_VERSION_MAJOR "${CMAKE_CXX_COMPILER_VERSION}")
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)(\\.[0-9]+)?" "\\2"
+    _boost_COMPILER_VERSION_MINOR "${CMAKE_CXX_COMPILER_VERSION}")
+
+  set(_boost_COMPILER_VERSION "${_boost_COMPILER_VERSION_MAJOR}${_boost_COMPILER_VERSION_MINOR}")
 
   set(${_OUTPUT_VERSION} ${_boost_COMPILER_VERSION} PARENT_SCOPE)
+  set(${_OUTPUT_VERSION_MAJOR} ${_boost_COMPILER_VERSION_MAJOR} PARENT_SCOPE)
+  set(${_OUTPUT_VERSION_MINOR} ${_boost_COMPILER_VERSION_MINOR} PARENT_SCOPE)
 endfunction()
 
 #
@@ -449,7 +875,8 @@ endfunction()
 # Guesses Boost's compiler prefix used in built library names
 # Returns the guess by setting the variable pointed to by _ret
 function(_Boost_GUESS_COMPILER_PREFIX _ret)
-  if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xIntel")
+  if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xIntel"
+      OR "x${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "xIntelLLVM")
     if(WIN32)
       set (_boost_COMPILER "-iw")
     else()
@@ -457,27 +884,32 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
     endif()
   elseif (GHSMULTI)
     set(_boost_COMPILER "-ghs")
-  elseif("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
-    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
-      set(_boost_COMPILER "-vc141;-vc140")
-    elseif (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
-      set(_boost_COMPILER "-vc140")
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
-      set(_boost_COMPILER "-vc120")
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)
-      set(_boost_COMPILER "-vc110")
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
-      set(_boost_COMPILER "-vc100")
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
-      set(_boost_COMPILER "-vc90")
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
-      set(_boost_COMPILER "-vc80")
+  elseif("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC" OR "x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC")
+    if(MSVC_TOOLSET_VERSION GREATER_EQUAL 150)
+      # Not yet known.
+      set(_boost_COMPILER "")
+    elseif(MSVC_TOOLSET_VERSION GREATER_EQUAL 140)
+      # MSVC toolset 14.x versions are forward compatible.
+      set(_boost_COMPILER "")
+      foreach(v 9 8 7 6 5 4 3 2 1 0)
+        if(MSVC_TOOLSET_VERSION GREATER_EQUAL 14${v})
+          list(APPEND _boost_COMPILER "-vc14${v}")
+        endif()
+      endforeach()
+    elseif(MSVC_TOOLSET_VERSION GREATER_EQUAL 80)
+      set(_boost_COMPILER "-vc${MSVC_TOOLSET_VERSION}")
     elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.10)
       set(_boost_COMPILER "-vc71")
     elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13) # Good luck!
       set(_boost_COMPILER "-vc7") # yes, this is correct
     else() # VS 6.0 Good luck!
       set(_boost_COMPILER "-vc6") # yes, this is correct
+    endif()
+
+    if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang")
+      string(REPLACE "." ";" VERSION_LIST "${CMAKE_CXX_COMPILER_VERSION}")
+      list(GET VERSION_LIST 0 CLANG_VERSION_MAJOR)
+      set(_boost_COMPILER "-clangw${CLANG_VERSION_MAJOR};${_boost_COMPILER}")
     endif()
   elseif (BORLAND)
     set(_boost_COMPILER "-bcb")
@@ -486,44 +918,56 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "XL")
     set(_boost_COMPILER "-xlc")
   elseif (MINGW)
-    if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_LESS 1.34)
+    if(Boost_VERSION_STRING VERSION_LESS 1.34)
         set(_boost_COMPILER "-mgw") # no GCC version encoding prior to 1.34
     else()
-      _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION)
-      set(_boost_COMPILER "-mgw${_boost_COMPILER_VERSION}")
+      _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION _boost_COMPILER_VERSION_MAJOR _boost_COMPILER_VERSION_MINOR)
+      if(Boost_VERSION_STRING VERSION_GREATER_EQUAL 1.73 AND _boost_COMPILER_VERSION_MAJOR VERSION_GREATER_EQUAL 5)
+        set(_boost_COMPILER "-mgw${_boost_COMPILER_VERSION_MAJOR}")
+      else()
+        set(_boost_COMPILER "-mgw${_boost_COMPILER_VERSION}")
+      endif()
     endif()
   elseif (UNIX)
-    if (CMAKE_COMPILER_IS_GNUCXX)
-      if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_LESS 1.34)
+    _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION _boost_COMPILER_VERSION_MAJOR _boost_COMPILER_VERSION_MINOR)
+    if(NOT Boost_VERSION_STRING VERSION_LESS 1.69.0)
+      # From GCC 5 and clang 4, versioning changes and minor becomes patch.
+      # For those compilers, patch is exclude from compiler tag in Boost 1.69+ library naming.
+      if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND _boost_COMPILER_VERSION_MAJOR VERSION_GREATER 4) OR CMAKE_CXX_COMPILER_ID STREQUAL "LCC")
+        set(_boost_COMPILER_VERSION "${_boost_COMPILER_VERSION_MAJOR}")
+      elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND _boost_COMPILER_VERSION_MAJOR VERSION_GREATER 3)
+        set(_boost_COMPILER_VERSION "${_boost_COMPILER_VERSION_MAJOR}")
+      endif()
+    endif()
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "LCC")
+      if(Boost_VERSION_STRING VERSION_LESS 1.34)
         set(_boost_COMPILER "-gcc") # no GCC version encoding prior to 1.34
       else()
-        _Boost_COMPILER_DUMPVERSION(_boost_COMPILER_VERSION)
         # Determine which version of GCC we have.
         if(APPLE)
-          if(Boost_MINOR_VERSION)
-            if(${Boost_MINOR_VERSION} GREATER 35)
-              # In Boost 1.36.0 and newer, the mangled compiler name used
-              # on Mac OS X/Darwin is "xgcc".
-              set(_boost_COMPILER "-xgcc${_boost_COMPILER_VERSION}")
-            else()
-              # In Boost <= 1.35.0, there is no mangled compiler name for
-              # the Mac OS X/Darwin version of GCC.
-              set(_boost_COMPILER "")
-            endif()
-          else()
-            # We don't know the Boost version, so assume it's
-            # pre-1.36.0.
+          if(Boost_VERSION_STRING VERSION_LESS 1.36.0)
+            # In Boost <= 1.35.0, there is no mangled compiler name for
+            # the macOS/Darwin version of GCC.
             set(_boost_COMPILER "")
+          else()
+            # In Boost 1.36.0 and newer, the mangled compiler name used
+            # on macOS/Darwin is "xgcc".
+            set(_boost_COMPILER "-xgcc${_boost_COMPILER_VERSION}")
           endif()
         else()
           set(_boost_COMPILER "-gcc${_boost_COMPILER_VERSION}")
         endif()
       endif()
-    endif ()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      # TODO: Find out any Boost version constraints vs clang support.
+      set(_boost_COMPILER "-clang${_boost_COMPILER_VERSION}")
+    endif()
   else()
-    # TODO at least Boost_DEBUG here?
     set(_boost_COMPILER "")
   endif()
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                         "_boost_COMPILER" SOURCE "guessed")
   set(${_ret} ${_boost_COMPILER} PARENT_SCOPE)
 endfunction()
 
@@ -561,15 +1005,14 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
   # - Indent
   #   s;^set(;    set(;;
   # - Add conditionals
-  #   s;Scanning /path/to/boost/sources/boost_\(.*\)_\(.*\)_\(.*);  elseif(NOT Boost_VERSION VERSION_LESS \10\20\3 AND Boost_VERSION VERSION_LESS xxxx);
+  #   s;Scanning /path/to/boost/sources/boost_\(.*\)_\(.*\)_\(.*);  elseif(NOT Boost_VERSION_STRING VERSION_LESS \1\.\2\.\3 AND Boost_VERSION_STRING VERSION_LESS xxxx);
   #
   # This results in the logic seen below, but will require the xxxx
   # replacing with the following Boost release version (or the next
   # minor version to be released, e.g. 1.59 was the latest at the time
-  # of writing, making 1.60 the next, so 106000 is the needed version
-  # number).  Identical consecutive releases were then merged together
-  # by updating the end range of the first block and removing the
-  # following redundant blocks.
+  # of writing, making 1.60 the next. Identical consecutive releases
+  # were then merged together by updating the end range of the first
+  # block and removing the following redundant blocks.
   #
   # Running the script against all historical releases should be
   # required only if the BoostScanDeps.cmake script logic is changed.
@@ -577,247 +1020,230 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
   # against the new release.
 
   # Handle Python version suffixes
-  if(component MATCHES "^(python|mpi_python|numpy)([0-9][0-9]?|[0-9]\\.[0-9])\$")
+  if(component MATCHES "^(python|mpi_python|numpy)([0-9][0-9]?|[0-9]\\.[0-9]+)\$")
     set(component "${CMAKE_MATCH_1}")
     set(component_python_version "${CMAKE_MATCH_2}")
   endif()
 
   set(_Boost_IMPORTED_TARGETS TRUE)
-  if(Boost_VERSION VERSION_LESS 103300)
-    message(WARNING "Imported targets and dependency information not available for Boost version ${Boost_VERSION} (all versions older than 1.33)")
-    set(_Boost_IMPORTED_TARGETS FALSE)
-  elseif(NOT Boost_VERSION VERSION_LESS 103300 AND Boost_VERSION VERSION_LESS 103500)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex thread)
-    set(_Boost_REGEX_DEPENDENCIES thread)
-    set(_Boost_WAVE_DEPENDENCIES filesystem thread)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 103500 AND Boost_VERSION VERSION_LESS 103600)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system thread)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 103600 AND Boost_VERSION VERSION_LESS 103800)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system thread)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 103800 AND Boost_VERSION VERSION_LESS 104300)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES date_time)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system thread date_time)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104300 AND Boost_VERSION VERSION_LESS 104400)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES date_time)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system thread date_time)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104400 AND Boost_VERSION VERSION_LESS 104500)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random serialization)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES date_time)
-    set(_Boost_WAVE_DEPENDENCIES serialization filesystem system thread date_time)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104500 AND Boost_VERSION VERSION_LESS 104700)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES date_time)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104700 AND Boost_VERSION VERSION_LESS 104800)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES date_time)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 104800 AND Boost_VERSION VERSION_LESS 105000)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES date_time)
-    set(_Boost_TIMER_DEPENDENCIES chrono system)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105000 AND Boost_VERSION VERSION_LESS 105300)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time)
-    set(_Boost_TIMER_DEPENDENCIES chrono system)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105300 AND Boost_VERSION VERSION_LESS 105400)
-    set(_Boost_ATOMIC_DEPENDENCIES thread chrono system date_time)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_TIMER_DEPENDENCIES chrono system)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105400 AND Boost_VERSION VERSION_LESS 105500)
-    set(_Boost_ATOMIC_DEPENDENCIES thread chrono system date_time)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_TIMER_DEPENDENCIES chrono system)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105500 AND Boost_VERSION VERSION_LESS 105600)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_COROUTINE_DEPENDENCIES context system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_TIMER_DEPENDENCIES chrono system)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105600 AND Boost_VERSION VERSION_LESS 105900)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_COROUTINE_DEPENDENCIES context system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_RANDOM_DEPENDENCIES system)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_TIMER_DEPENDENCIES chrono system)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 105900 AND Boost_VERSION VERSION_LESS 106000)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_COROUTINE_DEPENDENCIES context system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono atomic)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_RANDOM_DEPENDENCIES system)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_TIMER_DEPENDENCIES chrono system)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106000 AND Boost_VERSION VERSION_LESS 106100)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_COROUTINE_DEPENDENCIES context system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_RANDOM_DEPENDENCIES system)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_TIMER_DEPENDENCIES chrono system)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106100 AND Boost_VERSION VERSION_LESS 106200)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
-    set(_Boost_COROUTINE_DEPENDENCIES context system)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_RANDOM_DEPENDENCIES system)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106200 AND Boost_VERSION VERSION_LESS 106300)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
-    set(_Boost_COROUTINE_DEPENDENCIES context system)
-    set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_RANDOM_DEPENDENCIES system)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106300 AND Boost_VERSION VERSION_LESS 106500)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
-    set(_Boost_COROUTINE_DEPENDENCIES context system)
-    set(_Boost_COROUTINE2_DEPENDENCIES context fiber thread chrono system date_time)
-    set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_RANDOM_DEPENDENCIES system)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  elseif(NOT Boost_VERSION VERSION_LESS 106500 AND Boost_VERSION VERSION_LESS 106700)
-    set(_Boost_CHRONO_DEPENDENCIES system)
-    set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
-    set(_Boost_COROUTINE_DEPENDENCIES context system)
-    set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
-    set(_Boost_FILESYSTEM_DEPENDENCIES system)
-    set(_Boost_IOSTREAMS_DEPENDENCIES regex)
-    set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
-    set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
-    set(_Boost_MPI_DEPENDENCIES serialization)
-    set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
-    set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
-    set(_Boost_RANDOM_DEPENDENCIES system)
-    set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
-    set(_Boost_TIMER_DEPENDENCIES chrono system)
-    set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
-    set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-  else()
-    if(NOT Boost_VERSION VERSION_LESS 106700)
+  if(Boost_VERSION_STRING)
+    if(Boost_VERSION_STRING VERSION_LESS 1.33.0)
+      message(WARNING "Imported targets and dependency information not available for Boost version ${Boost_VERSION_STRING} (all versions older than 1.33)")
+      set(_Boost_IMPORTED_TARGETS FALSE)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.35.0)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex thread)
+      set(_Boost_REGEX_DEPENDENCIES thread)
+      set(_Boost_WAVE_DEPENDENCIES filesystem thread)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.36.0)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system thread)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.38.0)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system thread)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.43.0)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES date_time)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system thread date_time)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.44.0)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES date_time)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system thread date_time)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.45.0)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random serialization)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES date_time)
+      set(_Boost_WAVE_DEPENDENCIES serialization filesystem system thread date_time)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.47.0)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES date_time)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.48.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES date_time)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.50.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l random)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES date_time)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread date_time)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.53.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.54.0)
+      set(_Boost_ATOMIC_DEPENDENCIES thread chrono system date_time)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.55.0)
+      set(_Boost_ATOMIC_DEPENDENCIES thread chrono system date_time)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.56.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l regex random)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.59.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_RANDOM_DEPENDENCIES system)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.60.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES log_setup date_time system filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_RANDOM_DEPENDENCIES system)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.61.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_RANDOM_DEPENDENCIES system)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.62.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_RANDOM_DEPENDENCIES system)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.63.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_RANDOM_DEPENDENCIES system)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.65.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_COROUTINE2_DEPENDENCIES context fiber thread chrono system date_time)
+      set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_RANDOM_DEPENDENCIES system)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.67.0)
       set(_Boost_CHRONO_DEPENDENCIES system)
       set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
       set(_Boost_COROUTINE_DEPENDENCIES context system)
@@ -834,9 +1260,159 @@ function(_Boost_COMPONENT_DEPENDENCIES component _ret)
       set(_Boost_TIMER_DEPENDENCIES chrono system)
       set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
       set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
-    endif()
-    if(NOT Boost_VERSION VERSION_LESS 106800)
-      message(WARNING "New Boost version may have incorrect or missing dependencies and imported targets")
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.68.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_RANDOM_DEPENDENCIES system)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.69.0)
+      set(_Boost_CHRONO_DEPENDENCIES system)
+      set(_Boost_CONTEXT_DEPENDENCIES thread chrono system date_time)
+      set(_Boost_CONTRACT_DEPENDENCIES thread chrono system date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context system)
+      set(_Boost_FIBER_DEPENDENCIES context thread chrono system date_time)
+      set(_Boost_FILESYSTEM_DEPENDENCIES system)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup system filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_RANDOM_DEPENDENCIES system)
+      set(_Boost_THREAD_DEPENDENCIES chrono system date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem system serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.70.0)
+      set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context)
+      set(_Boost_FIBER_DEPENDENCIES context)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_THREAD_DEPENDENCIES chrono date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono system)
+      set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.72.0)
+      set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context)
+      set(_Boost_FIBER_DEPENDENCIES context)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_THREAD_DEPENDENCIES chrono date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono)
+      set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.73.0)
+      set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context)
+      set(_Boost_FIBER_DEPENDENCIES context)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l chrono atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_THREAD_DEPENDENCIES chrono date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono)
+      set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.75.0)
+      set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context)
+      set(_Boost_FIBER_DEPENDENCIES context)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_THREAD_DEPENDENCIES chrono date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono)
+      set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.77.0)
+      set(_Boost_CONTRACT_DEPENDENCIES thread chrono date_time)
+      set(_Boost_COROUTINE_DEPENDENCIES context)
+      set(_Boost_FIBER_DEPENDENCIES context)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_JSON_DEPENDENCIES container)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l atomic)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_THREAD_DEPENDENCIES chrono date_time atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono)
+      set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono date_time atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.78.0)
+      set(_Boost_CONTRACT_DEPENDENCIES thread chrono)
+      set(_Boost_COROUTINE_DEPENDENCIES context)
+      set(_Boost_FIBER_DEPENDENCIES context)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_JSON_DEPENDENCIES container)
+      set(_Boost_LOG_DEPENDENCIES date_time log_setup filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_THREAD_DEPENDENCIES chrono atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono)
+      set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    elseif(Boost_VERSION_STRING VERSION_LESS 1.83.0)
+      set(_Boost_CONTRACT_DEPENDENCIES thread chrono)
+      set(_Boost_COROUTINE_DEPENDENCIES context)
+      set(_Boost_FIBER_DEPENDENCIES context)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_JSON_DEPENDENCIES container)
+      set(_Boost_LOG_DEPENDENCIES log_setup filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_THREAD_DEPENDENCIES chrono atomic)
+      set(_Boost_TIMER_DEPENDENCIES chrono)
+      set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+    else()
+      set(_Boost_CONTRACT_DEPENDENCIES thread chrono)
+      set(_Boost_COROUTINE_DEPENDENCIES context)
+      set(_Boost_FIBER_DEPENDENCIES context)
+      set(_Boost_IOSTREAMS_DEPENDENCIES regex)
+      set(_Boost_JSON_DEPENDENCIES container)
+      set(_Boost_LOG_DEPENDENCIES log_setup filesystem thread regex chrono atomic)
+      set(_Boost_MATH_DEPENDENCIES math_c99 math_c99f math_c99l math_tr1 math_tr1f math_tr1l)
+      set(_Boost_MPI_DEPENDENCIES serialization)
+      set(_Boost_MPI_PYTHON_DEPENDENCIES python${component_python_version} mpi serialization)
+      set(_Boost_NUMPY_DEPENDENCIES python${component_python_version})
+      set(_Boost_THREAD_DEPENDENCIES chrono atomic)
+      set(_Boost_WAVE_DEPENDENCIES filesystem serialization thread chrono atomic)
+      set(_Boost_WSERIALIZATION_DEPENDENCIES serialization)
+      if(Boost_VERSION_STRING VERSION_GREATER_EQUAL 1.86.0 AND NOT Boost_NO_WARN_NEW_VERSIONS)
+        message(WARNING "New Boost version may have incorrect or missing dependencies and imported targets")
+      endif()
     endif()
   endif()
 
@@ -862,7 +1438,7 @@ endfunction()
 #
 function(_Boost_COMPONENT_HEADERS component _hdrs)
   # Handle Python version suffixes
-  if(component MATCHES "^(python|mpi_python|numpy)([0-9][0-9]?|[0-9]\\.[0-9])\$")
+  if(component MATCHES "^(python|mpi_python|numpy)([0-9]+|[0-9]\\.[0-9]+)\$")
     set(component "${CMAKE_MATCH_1}")
     set(component_python_version "${CMAKE_MATCH_2}")
   endif()
@@ -872,7 +1448,12 @@ function(_Boost_COMPONENT_HEADERS component _hdrs)
   set(_Boost_ATOMIC_HEADERS              "boost/atomic.hpp")
   set(_Boost_CHRONO_HEADERS              "boost/chrono.hpp")
   set(_Boost_CONTAINER_HEADERS           "boost/container/container_fwd.hpp")
-  set(_Boost_CONTEXT_HEADERS             "boost/context/all.hpp")
+  set(_Boost_CONTRACT_HEADERS            "boost/contract.hpp")
+  if(Boost_VERSION_STRING VERSION_LESS 1.61.0)
+    set(_Boost_CONTEXT_HEADERS           "boost/context/all.hpp")
+  else()
+    set(_Boost_CONTEXT_HEADERS           "boost/context/detail/fcontext.hpp")
+  endif()
   set(_Boost_COROUTINE_HEADERS           "boost/coroutine/all.hpp")
   set(_Boost_DATE_TIME_HEADERS           "boost/date_time/date.hpp")
   set(_Boost_EXCEPTION_HEADERS           "boost/exception/exception.hpp")
@@ -884,6 +1465,7 @@ function(_Boost_COMPONENT_HEADERS component _hdrs)
   set(_Boost_LOCALE_HEADERS              "boost/locale.hpp")
   set(_Boost_LOG_HEADERS                 "boost/log/core.hpp")
   set(_Boost_LOG_SETUP_HEADERS           "boost/log/detail/setup_config.hpp")
+  set(_Boost_JSON_HEADERS                "boost/json.hpp")
   set(_Boost_MATH_HEADERS                "boost/math_fwd.hpp")
   set(_Boost_MATH_C99_HEADERS            "boost/math/tr1.hpp")
   set(_Boost_MATH_C99F_HEADERS           "boost/math/tr1.hpp")
@@ -893,7 +1475,9 @@ function(_Boost_COMPONENT_HEADERS component _hdrs)
   set(_Boost_MATH_TR1L_HEADERS           "boost/math/tr1.hpp")
   set(_Boost_MPI_HEADERS                 "boost/mpi.hpp")
   set(_Boost_MPI_PYTHON_HEADERS          "boost/mpi/python/config.hpp")
+  set(_Boost_MYSQL_HEADERS               "boost/mysql.hpp")
   set(_Boost_NUMPY_HEADERS               "boost/python/numpy.hpp")
+  set(_Boost_NOWIDE_HEADERS              "boost/nowide/cstdlib.hpp")
   set(_Boost_PRG_EXEC_MONITOR_HEADERS    "boost/test/prg_exec_monitor.hpp")
   set(_Boost_PROGRAM_OPTIONS_HEADERS     "boost/program_options.hpp")
   set(_Boost_PYTHON_HEADERS              "boost/python.hpp")
@@ -901,18 +1485,23 @@ function(_Boost_COMPONENT_HEADERS component _hdrs)
   set(_Boost_REGEX_HEADERS               "boost/regex.hpp")
   set(_Boost_SERIALIZATION_HEADERS       "boost/serialization/serialization.hpp")
   set(_Boost_SIGNALS_HEADERS             "boost/signals.hpp")
+  set(_Boost_STACKTRACE_ADDR2LINE_HEADERS "boost/stacktrace.hpp")
+  set(_Boost_STACKTRACE_BACKTRACE_HEADERS "boost/stacktrace.hpp")
+  set(_Boost_STACKTRACE_BASIC_HEADERS    "boost/stacktrace.hpp")
+  set(_Boost_STACKTRACE_NOOP_HEADERS     "boost/stacktrace.hpp")
+  set(_Boost_STACKTRACE_WINDBG_CACHED_HEADERS "boost/stacktrace.hpp")
+  set(_Boost_STACKTRACE_WINDBG_HEADERS   "boost/stacktrace.hpp")
   set(_Boost_SYSTEM_HEADERS              "boost/system/config.hpp")
   set(_Boost_TEST_EXEC_MONITOR_HEADERS   "boost/test/test_exec_monitor.hpp")
   set(_Boost_THREAD_HEADERS              "boost/thread.hpp")
   set(_Boost_TIMER_HEADERS               "boost/timer.hpp")
   set(_Boost_TYPE_ERASURE_HEADERS        "boost/type_erasure/config.hpp")
   set(_Boost_UNIT_TEST_FRAMEWORK_HEADERS "boost/test/framework.hpp")
+  set(_Boost_URL_HEADERS                 "boost/url.hpp")
   set(_Boost_WAVE_HEADERS                "boost/wave.hpp")
   set(_Boost_WSERIALIZATION_HEADERS      "boost/archive/text_wiarchive.hpp")
-  if(WIN32)
-    set(_Boost_BZIP2_HEADERS             "boost/iostreams/filter/bzip2.hpp")
-    set(_Boost_ZLIB_HEADERS              "boost/iostreams/filter/zlib.hpp")
-  endif()
+  set(_Boost_BZIP2_HEADERS               "boost/iostreams/filter/bzip2.hpp")
+  set(_Boost_ZLIB_HEADERS                "boost/iostreams/filter/zlib.hpp")
 
   string(TOUPPER ${component} uppercomponent)
   set(${_hdrs} ${_Boost_${uppercomponent}_HEADERS} PARENT_SCOPE)
@@ -971,11 +1560,17 @@ endfunction()
 # Some boost libraries may require particular set of compler features.
 # The very first one was `boost::fiber` introduced in Boost 1.62.
 # One can check required compiler features of it in
-# `${Boost_ROOT}/libs/fiber/build/Jamfile.v2`.
+# - `${Boost_ROOT}/libs/fiber/build/Jamfile.v2`;
+# - `${Boost_ROOT}/libs/context/build/Jamfile.v2`.
+#
+# TODO (Re)Check compiler features on (every?) release ???
+# One may use the following command to get the files to check:
+#
+#   $ find . -name Jamfile.v2 | grep build | xargs grep -l cxx1
 #
 function(_Boost_COMPILER_FEATURES component _ret)
-  # Boost >= 1.62 and < 1.67
-  if(NOT Boost_VERSION VERSION_LESS 106200 AND Boost_VERSION VERSION_LESS 106700)
+  # Boost >= 1.62
+  if(NOT Boost_VERSION_STRING VERSION_LESS 1.62.0)
     set(_Boost_FIBER_COMPILER_FEATURES
         cxx_alias_templates
         cxx_auto_type
@@ -989,7 +1584,19 @@ function(_Boost_COMPILER_FEATURES component _ret)
         cxx_thread_local
         cxx_variadic_templates
     )
+    # Compiler feature for `context` same as for `fiber`.
+    set(_Boost_CONTEXT_COMPILER_FEATURES ${_Boost_FIBER_COMPILER_FEATURES})
   endif()
+
+  # Boost Contract library available in >= 1.67
+  if(NOT Boost_VERSION_STRING VERSION_LESS 1.67.0)
+    # From `libs/contract/build/boost_contract_build.jam`
+    set(_Boost_CONTRACT_COMPILER_FEATURES
+        cxx_lambdas
+        cxx_variadic_templates
+    )
+  endif()
+
   string(TOUPPER ${component} uppercomponent)
   set(${_ret} ${_Boost_${uppercomponent}_COMPILER_FEATURES} PARENT_SCOPE)
 endfunction()
@@ -1009,21 +1616,18 @@ function(_Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS component
     else()
       set(_arch_suffix 32)
     endif()
-    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.1)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.0)
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.0)
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-12.0)
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-11.0)
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-10.0)
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-9.0)
-    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
-      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-8.0)
+    if(MSVC_TOOLSET_VERSION GREATER_EQUAL 150)
+      # Not yet known.
+    elseif(MSVC_TOOLSET_VERSION GREATER_EQUAL 140)
+      # MSVC toolset 14.x versions are forward compatible.
+      foreach(v 9 8 7 6 5 4 3 2 1 0)
+        if(MSVC_TOOLSET_VERSION GREATER_EQUAL 14${v})
+          list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-14.${v})
+        endif()
+      endforeach()
+    elseif(MSVC_TOOLSET_VERSION GREATER_EQUAL 80)
+      math(EXPR _toolset_major_version "${MSVC_TOOLSET_VERSION} / 10")
+      list(APPEND ${componentlibvar} ${basedir}/lib${_arch_suffix}-msvc-${_toolset_major_version}.0)
     endif()
     set(${componentlibvar} ${${componentlibvar}} PARENT_SCOPE)
   endif()
@@ -1081,7 +1685,11 @@ else()
   # _Boost_COMPONENT_HEADERS.  See the instructions at the top of
   # _Boost_COMPONENT_DEPENDENCIES.
   set(_Boost_KNOWN_VERSIONS ${Boost_ADDITIONAL_VERSIONS}
-    "1.67.0" "1.67" "1.66.0" "1.66" "1.65.1" "1.65.0" "1.65"
+    "1.85.0" "1.85" "1.84.0" "1.84"
+    "1.83.0" "1.83" "1.82.0" "1.82" "1.81.0" "1.81" "1.80.0" "1.80" "1.79.0" "1.79"
+    "1.78.0" "1.78" "1.77.0" "1.77" "1.76.0" "1.76" "1.75.0" "1.75" "1.74.0" "1.74"
+    "1.73.0" "1.73" "1.72.0" "1.72" "1.71.0" "1.71" "1.70.0" "1.70" "1.69.0" "1.69"
+    "1.68.0" "1.68" "1.67.0" "1.67" "1.66.0" "1.66" "1.65.1" "1.65.0" "1.65"
     "1.64.0" "1.64" "1.63.0" "1.63" "1.62.0" "1.62" "1.61.0" "1.61" "1.60.0" "1.60"
     "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56" "1.55.0" "1.55"
     "1.54.0" "1.54" "1.53.0" "1.53" "1.52.0" "1.52" "1.51.0" "1.51"
@@ -1111,65 +1719,18 @@ else()
   endif()
 endif()
 
-# The reason that we failed to find Boost. This will be set to a
-# user-friendly message when we fail to find some necessary piece of
-# Boost.
-set(Boost_ERROR_REASON)
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_TEST_VERSIONS")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_USE_MULTITHREADED")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_USE_STATIC_LIBS")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_USE_STATIC_RUNTIME")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_ADDITIONAL_VERSIONS")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_NO_SYSTEM_PATHS")
 
-if(Boost_DEBUG)
-  # Output some of their choices
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "_boost_TEST_VERSIONS = ${_boost_TEST_VERSIONS}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_USE_MULTITHREADED = ${Boost_USE_MULTITHREADED}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_USE_STATIC_LIBS = ${Boost_USE_STATIC_LIBS}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_USE_STATIC_RUNTIME = ${Boost_USE_STATIC_RUNTIME}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_ADDITIONAL_VERSIONS = ${Boost_ADDITIONAL_VERSIONS}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Boost_NO_SYSTEM_PATHS = ${Boost_NO_SYSTEM_PATHS}")
+cmake_policy(GET CMP0074 _Boost_CMP0074)
+if(NOT "x${_Boost_CMP0074}x" STREQUAL "xNEWx")
+  _Boost_CHECK_SPELLING(Boost_ROOT)
 endif()
-
-# Supply Boost_LIB_DIAGNOSTIC_DEFINITIONS as a convenience target. It
-# will only contain any interface definitions on WIN32, but is created
-# on all platforms to keep end user code free from platform dependent
-# code.  Also provide convenience targets to disable autolinking and
-# enable dynamic linking.
-if(NOT TARGET Boost::diagnostic_definitions)
-  add_library(Boost::diagnostic_definitions INTERFACE IMPORTED)
-  add_library(Boost::disable_autolinking INTERFACE IMPORTED)
-  add_library(Boost::dynamic_linking INTERFACE IMPORTED)
-endif()
-if(WIN32)
-  # In windows, automatic linking is performed, so you do not have
-  # to specify the libraries.  If you are linking to a dynamic
-  # runtime, then you can choose to link to either a static or a
-  # dynamic Boost library, the default is to do a static link.  You
-  # can alter this for a specific library "whatever" by defining
-  # BOOST_WHATEVER_DYN_LINK to force Boost library "whatever" to be
-  # linked dynamically.  Alternatively you can force all Boost
-  # libraries to dynamic link by defining BOOST_ALL_DYN_LINK.
-
-  # This feature can be disabled for Boost library "whatever" by
-  # defining BOOST_WHATEVER_NO_LIB, or for all of Boost by defining
-  # BOOST_ALL_NO_LIB.
-
-  # If you want to observe which libraries are being linked against
-  # then defining BOOST_LIB_DIAGNOSTIC will cause the auto-linking
-  # code to emit a #pragma message each time a library is selected
-  # for linking.
-  set(Boost_LIB_DIAGNOSTIC_DEFINITIONS "-DBOOST_LIB_DIAGNOSTIC")
-  set_target_properties(Boost::diagnostic_definitions PROPERTIES
-    INTERFACE_COMPILE_DEFINITIONS "BOOST_LIB_DIAGNOSTIC")
-  set_target_properties(Boost::disable_autolinking PROPERTIES
-    INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_NO_LIB")
-  set_target_properties(Boost::dynamic_linking PROPERTIES
-    INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_DYN_LINK")
-endif()
-
-_Boost_CHECK_SPELLING(Boost_ROOT)
+unset(_Boost_CMP0074)
 _Boost_CHECK_SPELLING(Boost_LIBRARYDIR)
 _Boost_CHECK_SPELLING(Boost_INCLUDEDIR)
 
@@ -1195,18 +1756,12 @@ set(_Boost_VARS_DIR
   Boost_NO_SYSTEM_PATHS
   )
 
-if(Boost_DEBUG)
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "Declared as CMake or Environmental Variables:")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "  BOOST_ROOT = ${BOOST_ROOT}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "  BOOST_INCLUDEDIR = ${BOOST_INCLUDEDIR}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "  BOOST_LIBRARYDIR = ${BOOST_LIBRARYDIR}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                 "_boost_TEST_VERSIONS = ${_boost_TEST_VERSIONS}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_ROOT")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_ROOT" ENVIRONMENT)
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_INCLUDEDIR")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_INCLUDEDIR" ENVIRONMENT)
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_LIBRARYDIR")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "BOOST_LIBRARYDIR" ENVIRONMENT)
 
 # ------------------------------------------------------------------------
 #  Search for Boost include DIR
@@ -1238,7 +1793,7 @@ if(NOT Boost_INCLUDE_DIR)
     list(APPEND _boost_INCLUDE_SEARCH_DIRS NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH)
   else()
     if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
-      foreach(ver ${_Boost_KNOWN_VERSIONS})
+      foreach(ver ${_boost_TEST_VERSIONS})
         string(REPLACE "." "_" ver "${ver}")
         list(APPEND _boost_INCLUDE_SEARCH_DIRS PATHS "C:/local/boost_${ver}")
       endforeach()
@@ -1278,14 +1833,8 @@ if(NOT Boost_INCLUDE_DIR)
 
   endforeach()
 
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "Include debugging info:")
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "  _boost_INCLUDE_SEARCH_DIRS = ${_boost_INCLUDE_SEARCH_DIRS}")
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "  _boost_PATH_SUFFIXES = ${_boost_PATH_SUFFIXES}")
-  endif()
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_INCLUDE_SEARCH_DIRS")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_PATH_SUFFIXES")
 
   # Look for a standard boost header file.
   find_path(Boost_INCLUDE_DIR
@@ -1299,88 +1848,79 @@ endif()
 #  Extract version information from version.hpp
 # ------------------------------------------------------------------------
 
-# Set Boost_FOUND based only on header location and version.
-# It will be updated below for component libraries.
 if(Boost_INCLUDE_DIR)
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "location of version.hpp: ${Boost_INCLUDE_DIR}/boost/version.hpp")
-  endif()
+  _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                     "location of version.hpp: ${Boost_INCLUDE_DIR}/boost/version.hpp")
 
-  # Extract Boost_VERSION and Boost_LIB_VERSION from version.hpp
-  set(Boost_VERSION 0)
+  # Extract Boost_VERSION_MACRO and Boost_LIB_VERSION from version.hpp
+  set(Boost_VERSION_MACRO 0)
   set(Boost_LIB_VERSION "")
   file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _boost_VERSION_HPP_CONTENTS REGEX "#define BOOST_(LIB_)?VERSION ")
-  set(_Boost_VERSION_REGEX "([0-9]+)")
-  set(_Boost_LIB_VERSION_REGEX "\"([0-9_]+)\"")
-  foreach(v VERSION LIB_VERSION)
-    if("${_boost_VERSION_HPP_CONTENTS}" MATCHES "#define BOOST_${v} ${_Boost_${v}_REGEX}")
-      set(Boost_${v} "${CMAKE_MATCH_1}")
-    endif()
-  endforeach()
+  if("${_boost_VERSION_HPP_CONTENTS}" MATCHES "#define BOOST_VERSION ([0-9]+)")
+    set(Boost_VERSION_MACRO "${CMAKE_MATCH_1}")
+  endif()
+  if("${_boost_VERSION_HPP_CONTENTS}" MATCHES "#define BOOST_LIB_VERSION \"([0-9_]+)\"")
+    set(Boost_LIB_VERSION "${CMAKE_MATCH_1}")
+  endif()
   unset(_boost_VERSION_HPP_CONTENTS)
 
-  math(EXPR Boost_MAJOR_VERSION "${Boost_VERSION} / 100000")
-  math(EXPR Boost_MINOR_VERSION "${Boost_VERSION} / 100 % 1000")
-  math(EXPR Boost_SUBMINOR_VERSION "${Boost_VERSION} % 100")
+  # Calculate version components
+  math(EXPR Boost_VERSION_MAJOR "${Boost_VERSION_MACRO} / 100000")
+  math(EXPR Boost_VERSION_MINOR "${Boost_VERSION_MACRO} / 100 % 1000")
+  math(EXPR Boost_VERSION_PATCH "${Boost_VERSION_MACRO} % 100")
+  set(Boost_VERSION_COUNT 3)
 
-  string(APPEND Boost_ERROR_REASON
-    "Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}\nBoost include path: ${Boost_INCLUDE_DIR}")
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "version.hpp reveals boost "
-                   "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-  endif()
+  # Define alias variables for backwards compat.
+  set(Boost_MAJOR_VERSION ${Boost_VERSION_MAJOR})
+  set(Boost_MINOR_VERSION ${Boost_VERSION_MINOR})
+  set(Boost_SUBMINOR_VERSION ${Boost_VERSION_PATCH})
 
-  if(Boost_FIND_VERSION)
-    # Set Boost_FOUND based on requested version.
-    set(_Boost_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-    if("${_Boost_VERSION}" VERSION_LESS "${Boost_FIND_VERSION}")
-      set(Boost_FOUND 0)
-      set(_Boost_VERSION_AGE "old")
-    elseif(Boost_FIND_VERSION_EXACT AND
-        NOT "${_Boost_VERSION}" VERSION_EQUAL "${Boost_FIND_VERSION}")
-      set(Boost_FOUND 0)
-      set(_Boost_VERSION_AGE "new")
-    else()
-      set(Boost_FOUND 1)
-    endif()
-    if(NOT Boost_FOUND)
-      # State that we found a version of Boost that is too new or too old.
-      string(APPEND Boost_ERROR_REASON
-        "\nDetected version of Boost is too ${_Boost_VERSION_AGE}. Requested version was ${Boost_FIND_VERSION_MAJOR}.${Boost_FIND_VERSION_MINOR}")
-      if (Boost_FIND_VERSION_PATCH)
-        string(APPEND Boost_ERROR_REASON
-          ".${Boost_FIND_VERSION_PATCH}")
-      endif ()
-      if (NOT Boost_FIND_VERSION_EXACT)
-        string(APPEND Boost_ERROR_REASON " (or newer)")
-      endif ()
-      string(APPEND Boost_ERROR_REASON ".")
-    endif ()
+  # Define Boost version in x.y.z format
+  set(Boost_VERSION_STRING "${Boost_VERSION_MAJOR}.${Boost_VERSION_MINOR}.${Boost_VERSION_PATCH}")
+
+  # Define final Boost_VERSION
+  cmake_policy(GET CMP0093 _Boost_CMP0093
+    PARENT_SCOPE # undocumented, do not use outside of CMake
+  )
+  if("x${_Boost_CMP0093}x" STREQUAL "xNEWx")
+    set(Boost_VERSION ${Boost_VERSION_STRING})
   else()
-    # Caller will accept any Boost version.
-    set(Boost_FOUND 1)
+    set(Boost_VERSION ${Boost_VERSION_MACRO})
   endif()
-else()
-  set(Boost_FOUND 0)
-  string(APPEND Boost_ERROR_REASON
-    "Unable to find the Boost header files. Please set BOOST_ROOT to the root directory containing Boost or BOOST_INCLUDEDIR to the directory containing Boost's headers.")
+  unset(_Boost_CMP0093)
+
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_STRING")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_MACRO")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_MAJOR")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_MINOR")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_PATCH")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_VERSION_COUNT")
 endif()
 
 # ------------------------------------------------------------------------
 #  Prefix initialization
 # ------------------------------------------------------------------------
 
-set(Boost_LIB_PREFIX "")
-if ( (GHSMULTI AND Boost_USE_STATIC_LIBS) OR
-    (WIN32 AND Boost_USE_STATIC_LIBS AND NOT CYGWIN) )
-  set(Boost_LIB_PREFIX "lib")
+if ( NOT DEFINED Boost_LIB_PREFIX )
+  # Boost's static libraries use a "lib" prefix on DLL platforms
+  # to distinguish them from the DLL import libraries.
+  if (Boost_USE_STATIC_LIBS AND (
+      (WIN32 AND NOT CYGWIN)
+      OR GHSMULTI
+      ))
+    set(Boost_LIB_PREFIX "lib")
+  else()
+    set(Boost_LIB_PREFIX "")
+  endif()
 endif()
 
 if ( NOT Boost_NAMESPACE )
   set(Boost_NAMESPACE "boost")
 endif()
+
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_LIB_PREFIX")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "Boost_NAMESPACE")
 
 # ------------------------------------------------------------------------
 #  Suffix initialization and compiler suffix detection.
@@ -1402,30 +1942,21 @@ _Boost_CHANGE_DETECT(_Boost_CHANGE_LIBNAME ${_Boost_VARS_NAME})
 # Setting some more suffixes for the library
 if (Boost_COMPILER)
   set(_boost_COMPILER ${Boost_COMPILER})
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "using user-specified Boost_COMPILER = ${_boost_COMPILER}")
-  endif()
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                         "_boost_COMPILER" SOURCE "user-specified via Boost_COMPILER")
 else()
   # Attempt to guess the compiler suffix
   # NOTE: this is not perfect yet, if you experience any issues
   # please report them and use the Boost_COMPILER variable
   # to work around the problems.
   _Boost_GUESS_COMPILER_PREFIX(_boost_COMPILER)
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-      "guessed _boost_COMPILER = ${_boost_COMPILER}")
-  endif()
 endif()
 
 set (_boost_MULTITHREADED "-mt")
 if( NOT Boost_USE_MULTITHREADED )
   set (_boost_MULTITHREADED "")
 endif()
-if(Boost_DEBUG)
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "_boost_MULTITHREADED = ${_boost_MULTITHREADED}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_MULTITHREADED")
 
 #======================
 # Systematically build up the Boost ABI tag for the 'tagged' and 'versioned' layouts
@@ -1447,7 +1978,8 @@ endif()
 if(WIN32 AND Boost_USE_DEBUG_RUNTIME)
   if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC"
           OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang"
-          OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xIntel")
+          OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xIntel"
+          OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xIntelLLVM")
     string(APPEND _boost_DEBUG_ABI_TAG "g")
   endif()
 endif()
@@ -1474,36 +2006,40 @@ endif()
 #  -x86     Architecture and address model tag
 #           First character is the architecture, then word-size, either 32 or 64
 #           Only used in 'versioned' layout, added in Boost 1.66.0
-set(_boost_ARCHITECTURE_TAG "")
-# {CMAKE_CXX_COMPILER_ARCHITECTURE_ID} is not currently set for all compilers
-if(NOT "x${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "x" AND NOT Boost_VERSION VERSION_LESS 106600)
-  string(APPEND _boost_ARCHITECTURE_TAG "-")
-  # This needs to be kept in-sync with the section of CMakePlatformId.h.in
-  # inside 'defined(_WIN32) && defined(_MSC_VER)'
-  if(${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} STREQUAL "IA64")
-    string(APPEND _boost_ARCHITECTURE_TAG "i")
-  elseif(${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} STREQUAL "X86"
-            OR ${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} STREQUAL "x64")
-    string(APPEND _boost_ARCHITECTURE_TAG "x")
-  elseif(${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} MATCHES "^ARM")
-    string(APPEND _boost_ARCHITECTURE_TAG "a")
-  elseif(${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} STREQUAL "MIPS")
-    string(APPEND _boost_ARCHITECTURE_TAG "m")
-  endif()
+if(DEFINED Boost_ARCHITECTURE)
+  set(_boost_ARCHITECTURE_TAG "${Boost_ARCHITECTURE}")
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                         "_boost_ARCHITECTURE_TAG" SOURCE "user-specified via Boost_ARCHITECTURE")
+else()
+  set(_boost_ARCHITECTURE_TAG "")
+  # {CMAKE_CXX_COMPILER_ARCHITECTURE_ID} is not currently set for all compilers
+  if(NOT "x${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "x" AND NOT Boost_VERSION_STRING VERSION_LESS 1.66.0)
+    string(APPEND _boost_ARCHITECTURE_TAG "-")
+    # This needs to be kept in-sync with the section of CMakePlatformId.h.in
+    # inside 'defined(_WIN32) && defined(_MSC_VER)'
+    if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "IA64")
+      string(APPEND _boost_ARCHITECTURE_TAG "i")
+    elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "X86"
+              OR CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "x64")
+      string(APPEND _boost_ARCHITECTURE_TAG "x")
+    elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "^ARM")
+      string(APPEND _boost_ARCHITECTURE_TAG "a")
+    elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "MIPS")
+      string(APPEND _boost_ARCHITECTURE_TAG "m")
+    endif()
 
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    string(APPEND _boost_ARCHITECTURE_TAG "64")
-  else()
-    string(APPEND _boost_ARCHITECTURE_TAG "32")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+      string(APPEND _boost_ARCHITECTURE_TAG "64")
+    else()
+      string(APPEND _boost_ARCHITECTURE_TAG "32")
+    endif()
   endif()
+  _Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                         "_boost_ARCHITECTURE_TAG" SOURCE "detected")
 endif()
 
-if(Boost_DEBUG)
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "_boost_RELEASE_ABI_TAG = ${_boost_RELEASE_ABI_TAG}")
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "_boost_DEBUG_ABI_TAG = ${_boost_DEBUG_ABI_TAG}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_RELEASE_ABI_TAG")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_DEBUG_ABI_TAG")
 
 # ------------------------------------------------------------------------
 #  Begin finding boost libraries
@@ -1549,7 +2085,7 @@ foreach(c DEBUG RELEASE)
     if( Boost_NO_SYSTEM_PATHS )
       list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH)
     else()
-      foreach(ver ${_Boost_KNOWN_VERSIONS})
+      foreach(ver ${_boost_TEST_VERSIONS})
         string(REPLACE "." "_" ver "${ver}")
         _Boost_UPDATE_WINDOWS_LIBRARY_SEARCH_DIRS_WITH_PREBUILT_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} "C:/local/boost_${ver}")
       endforeach()
@@ -1563,11 +2099,8 @@ foreach(c DEBUG RELEASE)
   endif()
 endforeach()
 
-if(Boost_DEBUG)
-  message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-    "_boost_LIBRARY_SEARCH_DIRS_RELEASE = ${_boost_LIBRARY_SEARCH_DIRS_RELEASE}"
-    "_boost_LIBRARY_SEARCH_DIRS_DEBUG   = ${_boost_LIBRARY_SEARCH_DIRS_DEBUG}")
-endif()
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_LIBRARY_SEARCH_DIRS_RELEASE")
+_Boost_DEBUG_PRINT_VAR("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}" "_boost_LIBRARY_SEARCH_DIRS_DEBUG")
 
 # Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
 if( Boost_USE_STATIC_LIBS )
@@ -1607,10 +2140,10 @@ endif()
 
 # On versions < 1.35, remove the System library from the considered list
 # since it wasn't added until 1.35.
-if(Boost_VERSION AND Boost_FIND_COMPONENTS)
-   if(Boost_VERSION LESS 103500)
-     list(REMOVE_ITEM Boost_FIND_COMPONENTS system)
-   endif()
+if(Boost_VERSION_STRING AND Boost_FIND_COMPONENTS)
+  if(Boost_VERSION_STRING VERSION_LESS 1.35.0)
+    list(REMOVE_ITEM Boost_FIND_COMPONENTS system)
+  endif()
 endif()
 
 # Additional components may be required via component dependencies.
@@ -1666,7 +2199,7 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
   if(${COMPONENT} MATCHES "^(python|mpi_python|numpy)([0-9])\$")
     set(COMPONENT_UNVERSIONED "${CMAKE_MATCH_1}")
     set(COMPONENT_PYTHON_VERSION_MAJOR "${CMAKE_MATCH_2}")
-  elseif(${COMPONENT} MATCHES "^(python|mpi_python|numpy)([0-9])\\.?([0-9])\$")
+  elseif(${COMPONENT} MATCHES "^(python|mpi_python|numpy)([0-9])\\.?([0-9]+)\$")
     set(COMPONENT_UNVERSIONED "${CMAKE_MATCH_1}")
     set(COMPONENT_PYTHON_VERSION_MAJOR "${CMAKE_MATCH_2}")
     set(COMPONENT_PYTHON_VERSION_MINOR "${CMAKE_MATCH_3}")
@@ -1680,7 +2213,7 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
     list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}${COMPONENT_PYTHON_VERSION_MAJOR}-py${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
     list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-py${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
     # Gentoo
-    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
+    list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-${COMPONENT_PYTHON_VERSION_MAJOR}.${COMPONENT_PYTHON_VERSION_MINOR}")
     # RPMs
     list(APPEND _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME "${COMPONENT_UNVERSIONED}-${COMPONENT_PYTHON_VERSION_MAJOR}${COMPONENT_PYTHON_VERSION_MINOR}")
   endif()
@@ -1692,19 +2225,13 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
   # Consolidate and report component-specific hints.
   if(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME)
     list(REMOVE_DUPLICATES _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME)
-    if(Boost_DEBUG)
-      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-        "Component-specific library search names for ${COMPONENT_NAME}: "
-        "${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME}")
-    endif()
+    _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+      "Component-specific library search names for ${COMPONENT_NAME}: ${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT_NAME}")
   endif()
   if(_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
     list(REMOVE_DUPLICATES _Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT)
-    if(Boost_DEBUG)
-      message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-        "Component-specific library search paths for ${COMPONENT}: "
-        "${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT}")
-    endif()
+    _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+      "Component-specific library search paths for ${COMPONENT}: ${_Boost_FIND_LIBRARY_HINTS_FOR_COMPONENT}")
   endif()
 
   #
@@ -1720,7 +2247,8 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
     endif()
   else()
     set(Boost_${UPPERCOMPONENT}_HEADER ON)
-    message(WARNING "No header defined for ${COMPONENT}; skipping header check")
+    message(WARNING "No header defined for ${COMPONENT}; skipping header check "
+                    "(note: header-only libraries have no designated component)")
   endif()
 
   #
@@ -1731,31 +2259,34 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
     foreach(compiler IN LISTS _boost_COMPILER)
       list(APPEND _boost_RELEASE_NAMES
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG} )
     endforeach()
     list(APPEND _boost_RELEASE_NAMES
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}${_boost_ARCHITECTURE_TAG}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component} )
     if(_boost_STATIC_RUNTIME_WORKAROUND)
       set(_boost_RELEASE_STATIC_ABI_TAG "-s${_boost_RELEASE_ABI_TAG}")
       foreach(compiler IN LISTS _boost_COMPILER)
         list(APPEND _boost_RELEASE_NAMES
           ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+          ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}
           ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG} )
       endforeach()
       list(APPEND _boost_RELEASE_NAMES
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_RELEASE_STATIC_ABI_TAG} )
     endif()
   endforeach()
   if(Boost_THREADAPI AND ${COMPONENT} STREQUAL "thread")
     _Boost_PREPEND_LIST_WITH_THREADAPI(_boost_RELEASE_NAMES ${_boost_RELEASE_NAMES})
   endif()
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "Searching for ${UPPERCOMPONENT}_LIBRARY_RELEASE: ${_boost_RELEASE_NAMES}")
-  endif()
+  _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                     "Searching for ${UPPERCOMPONENT}_LIBRARY_RELEASE: ${_boost_RELEASE_NAMES}")
 
   # if Boost_LIBRARY_DIR_RELEASE is not defined,
   # but Boost_LIBRARY_DIR_DEBUG is, look there first for RELEASE libs
@@ -1783,10 +2314,12 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
     foreach(compiler IN LISTS _boost_COMPILER)
       list(APPEND _boost_DEBUG_NAMES
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG} )
     endforeach()
     list(APPEND _boost_DEBUG_NAMES
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+      ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}${_boost_ARCHITECTURE_TAG}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_ABI_TAG}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component} )
@@ -1795,20 +2328,20 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
       foreach(compiler IN LISTS _boost_COMPILER)
         list(APPEND _boost_DEBUG_NAMES
           ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+          ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}
           ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${compiler}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG} )
       endforeach()
       list(APPEND _boost_DEBUG_NAMES
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}-${Boost_LIB_VERSION}
+        ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG}${_boost_ARCHITECTURE_TAG}
         ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${component}${_boost_MULTITHREADED}${_boost_DEBUG_STATIC_ABI_TAG} )
     endif()
   endforeach()
   if(Boost_THREADAPI AND ${COMPONENT} STREQUAL "thread")
      _Boost_PREPEND_LIST_WITH_THREADAPI(_boost_DEBUG_NAMES ${_boost_DEBUG_NAMES})
   endif()
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
-                   "Searching for ${UPPERCOMPONENT}_LIBRARY_DEBUG: ${_boost_DEBUG_NAMES}")
-  endif()
+  _Boost_DEBUG_PRINT("${CMAKE_CURRENT_LIST_FILE}" "${CMAKE_CURRENT_LIST_LINE}"
+                     "Searching for ${UPPERCOMPONENT}_LIBRARY_DEBUG: ${_boost_DEBUG_NAMES}")
 
   # if Boost_LIBRARY_DIR_DEBUG is not defined,
   # but Boost_LIBRARY_DIR_RELEASE is, look there first for DEBUG libs
@@ -1861,57 +2394,25 @@ if(Boost_LIBRARY_DIRS)
   list(REMOVE_DUPLICATES Boost_LIBRARY_DIRS)
 endif()
 
-# The above setting of Boost_FOUND was based only on the header files.
-# Update it for the requested component libraries.
+# ------------------------------------------------------------------------
+#  Call FPHSA helper, see https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html
+# ------------------------------------------------------------------------
+
+# Define aliases as needed by the component handler in the FPHSA helper below
+foreach(_comp IN LISTS Boost_FIND_COMPONENTS)
+  string(TOUPPER ${_comp} _uppercomp)
+  if(DEFINED Boost_${_uppercomp}_FOUND)
+    set(Boost_${_comp}_FOUND ${Boost_${_uppercomp}_FOUND})
+  endif()
+endforeach()
+
+find_package_handle_standard_args(Boost
+  REQUIRED_VARS Boost_INCLUDE_DIR
+  VERSION_VAR Boost_VERSION_STRING
+  HANDLE_COMPONENTS)
+
 if(Boost_FOUND)
-  # The headers were found.  Check for requested component libs.
-  set(_boost_CHECKED_COMPONENT FALSE)
-  set(_Boost_MISSING_COMPONENTS "")
-  foreach(COMPONENT ${Boost_FIND_COMPONENTS})
-    string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
-    set(_boost_CHECKED_COMPONENT TRUE)
-    if(NOT Boost_${UPPERCOMPONENT}_FOUND AND Boost_FIND_REQUIRED_${COMPONENT})
-      list(APPEND _Boost_MISSING_COMPONENTS ${COMPONENT})
-    endif()
-  endforeach()
-  if(_Boost_MISSING_COMPONENTS AND _Boost_EXTRA_FIND_COMPONENTS)
-    # Optional indirect dependencies are not counted as missing.
-    list(REMOVE_ITEM _Boost_MISSING_COMPONENTS ${_Boost_EXTRA_FIND_COMPONENTS})
-  endif()
-
-  if(Boost_DEBUG)
-    message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] Boost_FOUND = ${Boost_FOUND}")
-  endif()
-
-  if (_Boost_MISSING_COMPONENTS)
-    set(Boost_FOUND 0)
-    # We were unable to find some libraries, so generate a sensible
-    # error message that lists the libraries we were unable to find.
-    string(APPEND Boost_ERROR_REASON
-      "\nCould not find the following")
-    if(Boost_USE_STATIC_LIBS)
-      string(APPEND Boost_ERROR_REASON " static")
-    endif()
-    string(APPEND Boost_ERROR_REASON
-      " Boost libraries:\n")
-    foreach(COMPONENT ${_Boost_MISSING_COMPONENTS})
-      string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
-      string(APPEND Boost_ERROR_REASON
-        "        ${Boost_NAMESPACE}_${COMPONENT}${Boost_ERROR_REASON_${UPPERCOMPONENT}}\n")
-    endforeach()
-
-    list(LENGTH Boost_FIND_COMPONENTS Boost_NUM_COMPONENTS_WANTED)
-    list(LENGTH _Boost_MISSING_COMPONENTS Boost_NUM_MISSING_COMPONENTS)
-    if (${Boost_NUM_COMPONENTS_WANTED} EQUAL ${Boost_NUM_MISSING_COMPONENTS})
-      string(APPEND Boost_ERROR_REASON
-        "No Boost libraries were found. You may need to set BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT to the location of Boost.")
-    else ()
-      string(APPEND Boost_ERROR_REASON
-        "Some (but not all) of the required Boost libraries were found. You may need to install these additional Boost libraries. Alternatively, set BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT to the location of Boost.")
-    endif ()
-  endif ()
-
-  if( NOT Boost_LIBRARY_DIRS AND NOT _boost_CHECKED_COMPONENT )
+  if( NOT Boost_LIBRARY_DIRS )
     # Compatibility Code for backwards compatibility with CMake
     # 2.4's FindBoost module.
 
@@ -1955,13 +2456,22 @@ endif()
 # ------------------------------------------------------------------------
 
 if(Boost_FOUND)
-  # For header-only libraries
-  if(NOT TARGET Boost::boost)
-    add_library(Boost::boost INTERFACE IMPORTED)
+  # The builtin CMake package in Boost 1.70+ introduces a new name
+  # for the header-only lib, let's provide the same UI in module mode
+  if(NOT TARGET Boost::headers)
+    add_library(Boost::headers INTERFACE IMPORTED)
     if(Boost_INCLUDE_DIRS)
-      set_target_properties(Boost::boost PROPERTIES
+      set_target_properties(Boost::headers PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
     endif()
+  endif()
+
+  # Define the old target name for header-only libraries for backwards
+  # compat.
+  if(NOT TARGET Boost::boost)
+    add_library(Boost::boost INTERFACE IMPORTED)
+    set_target_properties(Boost::boost
+      PROPERTIES INTERFACE_LINK_LIBRARIES Boost::headers)
   endif()
 
   foreach(COMPONENT ${Boost_FIND_COMPONENTS})
@@ -2016,46 +2526,60 @@ if(Boost_FOUND)
       endif()
     endif()
   endforeach()
+
+  # Supply Boost_LIB_DIAGNOSTIC_DEFINITIONS as a convenience target. It
+  # will only contain any interface definitions on WIN32, but is created
+  # on all platforms to keep end user code free from platform dependent
+  # code.  Also provide convenience targets to disable autolinking and
+  # enable dynamic linking.
+  if(NOT TARGET Boost::diagnostic_definitions)
+    add_library(Boost::diagnostic_definitions INTERFACE IMPORTED)
+    add_library(Boost::disable_autolinking INTERFACE IMPORTED)
+    add_library(Boost::dynamic_linking INTERFACE IMPORTED)
+    set_target_properties(Boost::dynamic_linking PROPERTIES
+      INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_DYN_LINK")
+  endif()
+  if(WIN32)
+    # In windows, automatic linking is performed, so you do not have
+    # to specify the libraries.  If you are linking to a dynamic
+    # runtime, then you can choose to link to either a static or a
+    # dynamic Boost library, the default is to do a static link.  You
+    # can alter this for a specific library "whatever" by defining
+    # BOOST_WHATEVER_DYN_LINK to force Boost library "whatever" to be
+    # linked dynamically.  Alternatively you can force all Boost
+    # libraries to dynamic link by defining BOOST_ALL_DYN_LINK.
+
+    # This feature can be disabled for Boost library "whatever" by
+    # defining BOOST_WHATEVER_NO_LIB, or for all of Boost by defining
+    # BOOST_ALL_NO_LIB.
+
+    # If you want to observe which libraries are being linked against
+    # then defining BOOST_LIB_DIAGNOSTIC will cause the auto-linking
+    # code to emit a #pragma message each time a library is selected
+    # for linking.
+    set(Boost_LIB_DIAGNOSTIC_DEFINITIONS "-DBOOST_LIB_DIAGNOSTIC")
+    set_target_properties(Boost::diagnostic_definitions PROPERTIES
+      INTERFACE_COMPILE_DEFINITIONS "BOOST_LIB_DIAGNOSTIC")
+    set_target_properties(Boost::disable_autolinking PROPERTIES
+      INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_NO_LIB")
+  endif()
 endif()
 
 # ------------------------------------------------------------------------
-#  Notification to end user about what was found
+#  Finalize
 # ------------------------------------------------------------------------
 
+# Report Boost_LIBRARIES
 set(Boost_LIBRARIES "")
-if(Boost_FOUND)
-  if(NOT Boost_FIND_QUIETLY)
-    message(STATUS "Boost version: ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-    if(Boost_FIND_COMPONENTS)
-      message(STATUS "Found the following Boost libraries:")
+foreach(_comp IN LISTS Boost_FIND_COMPONENTS)
+  string(TOUPPER ${_comp} _uppercomp)
+  if(Boost_${_uppercomp}_FOUND)
+    list(APPEND Boost_LIBRARIES ${Boost_${_uppercomp}_LIBRARY})
+    if(_comp STREQUAL "thread")
+      list(APPEND Boost_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
     endif()
   endif()
-  foreach( COMPONENT  ${Boost_FIND_COMPONENTS} )
-    string( TOUPPER ${COMPONENT} UPPERCOMPONENT )
-    if( Boost_${UPPERCOMPONENT}_FOUND )
-      if(NOT Boost_FIND_QUIETLY)
-        message (STATUS "  ${COMPONENT}")
-      endif()
-      list(APPEND Boost_LIBRARIES ${Boost_${UPPERCOMPONENT}_LIBRARY})
-    endif()
-  endforeach()
-else()
-  if(Boost_FIND_REQUIRED)
-    message(SEND_ERROR "Unable to find the requested Boost libraries.\n${Boost_ERROR_REASON}")
-  else()
-    if(NOT Boost_FIND_QUIETLY)
-      # we opt not to automatically output Boost_ERROR_REASON here as
-      # it could be quite lengthy and somewhat imposing in its requests
-      # Since Boost is not always a required dependency we'll leave this
-      # up to the end-user.
-      if(Boost_DEBUG OR Boost_DETAILED_FAILURE_MSG)
-        message(STATUS "Could NOT find Boost\n${Boost_ERROR_REASON}")
-      else()
-        message(STATUS "Could NOT find Boost")
-      endif()
-    endif()
-  endif()
-endif()
+endforeach()
 
 # Configure display of cache entries in GUI.
 foreach(v BOOSTROOT BOOST_ROOT ${_Boost_VARS_INC} ${_Boost_VARS_LIB})

--- a/cmake/FindPackageHandleStandardArgs.cmake
+++ b/cmake/FindPackageHandleStandardArgs.cmake
@@ -1,0 +1,614 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindPackageHandleStandardArgs
+-----------------------------
+
+This module provides functions intended to be used in :ref:`Find Modules`
+implementing :command:`find_package(<PackageName>)` calls.
+
+.. command:: find_package_handle_standard_args
+
+  This command handles the ``REQUIRED``, ``QUIET`` and version-related
+  arguments of :command:`find_package`.  It also sets the
+  ``<PackageName>_FOUND`` variable.  The package is considered found if all
+  variables listed contain valid results, e.g. valid filepaths.
+
+  There are two signatures:
+
+  .. code-block:: cmake
+
+    find_package_handle_standard_args(<PackageName>
+      (DEFAULT_MSG|<custom-failure-message>)
+      <required-var>...
+      )
+
+    find_package_handle_standard_args(<PackageName>
+      [FOUND_VAR <result-var>]
+      [REQUIRED_VARS <required-var>...]
+      [VERSION_VAR <version-var>]
+      [HANDLE_VERSION_RANGE]
+      [HANDLE_COMPONENTS]
+      [CONFIG_MODE]
+      [NAME_MISMATCHED]
+      [REASON_FAILURE_MESSAGE <reason-failure-message>]
+      [FAIL_MESSAGE <custom-failure-message>]
+      )
+
+  The ``<PackageName>_FOUND`` variable will be set to ``TRUE`` if all
+  the variables ``<required-var>...`` are valid and any optional
+  constraints are satisfied, and ``FALSE`` otherwise.  A success or
+  failure message may be displayed based on the results and on
+  whether the ``REQUIRED`` and/or ``QUIET`` option was given to
+  the :command:`find_package` call.
+
+  The options are:
+
+  ``(DEFAULT_MSG|<custom-failure-message>)``
+    In the simple signature this specifies the failure message.
+    Use ``DEFAULT_MSG`` to ask for a default message to be computed
+    (recommended).  Not valid in the full signature.
+
+  ``FOUND_VAR <result-var>``
+    .. deprecated:: 3.3
+
+    Specifies either ``<PackageName>_FOUND`` or
+    ``<PACKAGENAME>_FOUND`` as the result variable.  This exists only
+    for compatibility with older versions of CMake and is now ignored.
+    Result variables of both names are always set for compatibility.
+
+  ``REQUIRED_VARS <required-var>...``
+    Specify the variables which are required for this package.
+    These may be named in the generated failure message asking the
+    user to set the missing variable values.  Therefore these should
+    typically be cache entries such as ``FOO_LIBRARY`` and not output
+    variables like ``FOO_LIBRARIES``.
+
+    .. versionchanged:: 3.18
+      If ``HANDLE_COMPONENTS`` is specified, this option can be omitted.
+
+  ``VERSION_VAR <version-var>``
+    Specify the name of a variable that holds the version of the package
+    that has been found.  This version will be checked against the
+    (potentially) specified required version given to the
+    :command:`find_package` call, including its ``EXACT`` option.
+    The default messages include information about the required
+    version and the version which has been actually found, both
+    if the version is ok or not.
+
+  ``HANDLE_VERSION_RANGE``
+    .. versionadded:: 3.19
+
+    Enable handling of a version range, if one is specified. Without this
+    option, a developer warning will be displayed if a version range is
+    specified.
+
+  ``HANDLE_COMPONENTS``
+    Enable handling of package components.  In this case, the command
+    will report which components have been found and which are missing,
+    and the ``<PackageName>_FOUND`` variable will be set to ``FALSE``
+    if any of the required components (i.e. not the ones listed after
+    the ``OPTIONAL_COMPONENTS`` option of :command:`find_package`) are
+    missing.
+
+  ``CONFIG_MODE``
+    Specify that the calling find module is a wrapper around a
+    call to ``find_package(<PackageName> NO_MODULE)``.  This implies
+    a ``VERSION_VAR`` value of ``<PackageName>_VERSION``.  The command
+    will automatically check whether the package configuration file
+    was found.
+
+  ``REASON_FAILURE_MESSAGE <reason-failure-message>``
+    .. versionadded:: 3.16
+
+    Specify a custom message of the reason for the failure which will be
+    appended to the default generated message.
+
+  ``FAIL_MESSAGE <custom-failure-message>``
+    Specify a custom failure message instead of using the default
+    generated message.  Not recommended.
+
+  ``NAME_MISMATCHED``
+    .. versionadded:: 3.17
+
+    Indicate that the ``<PackageName>`` does not match
+    ``${CMAKE_FIND_PACKAGE_NAME}``. This is usually a mistake and raises a
+    warning, but it may be intentional for usage of the command for components
+    of a larger package.
+
+Example for the simple signature:
+
+.. code-block:: cmake
+
+  find_package_handle_standard_args(LibXml2 DEFAULT_MSG
+    LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR)
+
+The ``LibXml2`` package is considered to be found if both
+``LIBXML2_LIBRARY`` and ``LIBXML2_INCLUDE_DIR`` are valid.
+Then also ``LibXml2_FOUND`` is set to ``TRUE``.  If it is not found
+and ``REQUIRED`` was used, it fails with a
+:command:`message(FATAL_ERROR)`, independent whether ``QUIET`` was
+used or not.  If it is found, success will be reported, including
+the content of the first ``<required-var>``.  On repeated CMake runs,
+the same message will not be printed again.
+
+.. note::
+
+  If ``<PackageName>`` does not match ``CMAKE_FIND_PACKAGE_NAME`` for the
+  calling module, a warning that there is a mismatch is given. The
+  ``FPHSA_NAME_MISMATCHED`` variable may be set to bypass the warning if using
+  the old signature and the ``NAME_MISMATCHED`` argument using the new
+  signature. To avoid forcing the caller to require newer versions of CMake for
+  usage, the variable's value will be used if defined when the
+  ``NAME_MISMATCHED`` argument is not passed for the new signature (but using
+  both is an error)..
+
+Example for the full signature:
+
+.. code-block:: cmake
+
+  find_package_handle_standard_args(LibArchive
+    REQUIRED_VARS LibArchive_LIBRARY LibArchive_INCLUDE_DIR
+    VERSION_VAR LibArchive_VERSION)
+
+In this case, the ``LibArchive`` package is considered to be found if
+both ``LibArchive_LIBRARY`` and ``LibArchive_INCLUDE_DIR`` are valid.
+Also the version of ``LibArchive`` will be checked by using the version
+contained in ``LibArchive_VERSION``.  Since no ``FAIL_MESSAGE`` is given,
+the default messages will be printed.
+
+Another example for the full signature:
+
+.. code-block:: cmake
+
+  find_package(Automoc4 QUIET NO_MODULE HINTS /opt/automoc4)
+  find_package_handle_standard_args(Automoc4  CONFIG_MODE)
+
+In this case, a ``FindAutmoc4.cmake`` module wraps a call to
+``find_package(Automoc4 NO_MODULE)`` and adds an additional search
+directory for ``automoc4``.  Then the call to
+``find_package_handle_standard_args`` produces a proper success/failure
+message.
+
+.. command:: find_package_check_version
+
+  .. versionadded:: 3.19
+
+  Helper function which can be used to check if a ``<version>`` is valid
+  against version-related arguments of :command:`find_package`.
+
+  .. code-block:: cmake
+
+    find_package_check_version(<version> <result-var>
+      [HANDLE_VERSION_RANGE]
+      [RESULT_MESSAGE_VARIABLE <message-var>]
+      )
+
+  The ``<result-var>`` will hold a boolean value giving the result of the check.
+
+  The options are:
+
+  ``HANDLE_VERSION_RANGE``
+    Enable handling of a version range, if one is specified. Without this
+    option, a developer warning will be displayed if a version range is
+    specified.
+
+  ``RESULT_MESSAGE_VARIABLE <message-var>``
+    Specify a variable to get back a message describing the result of the check.
+
+Example for the usage:
+
+.. code-block:: cmake
+
+  find_package_check_version(1.2.3 result HANDLE_VERSION_RANGE
+    RESULT_MESSAGE_VARIABLE reason)
+  if (result)
+    message (STATUS "${reason}")
+  else()
+    message (FATAL_ERROR "${reason}")
+  endif()
+#]=======================================================================]
+
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageMessage.cmake)
+
+
+cmake_policy(PUSH)
+# numbers and boolean constants
+cmake_policy (SET CMP0012 NEW)
+# IN_LIST operator
+cmake_policy (SET CMP0057 NEW)
+
+
+# internal helper macro
+macro(_FPHSA_FAILURE_MESSAGE _msg)
+  set (__msg "${_msg}")
+  if (FPHSA_REASON_FAILURE_MESSAGE)
+    string(APPEND __msg "\n    Reason given by package: ${FPHSA_REASON_FAILURE_MESSAGE}\n")
+  elseif(NOT DEFINED PROJECT_NAME)
+    string(APPEND __msg "\n"
+      "Hint: The project() command has not yet been called.  It sets up system-specific search paths.")
+  endif()
+  if (${_NAME}_FIND_REQUIRED)
+    message(FATAL_ERROR "${__msg}")
+  else ()
+    if (NOT ${_NAME}_FIND_QUIETLY)
+      message(STATUS "${__msg}")
+    endif ()
+  endif ()
+endmacro()
+
+
+# internal helper macro to generate the failure message when used in CONFIG_MODE:
+macro(_FPHSA_HANDLE_FAILURE_CONFIG_MODE)
+  # <PackageName>_CONFIG is set, but FOUND is false, this means that some other of the REQUIRED_VARS was not found:
+  if(${_NAME}_CONFIG)
+    _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: missing:${MISSING_VARS} (found ${${_NAME}_CONFIG} ${VERSION_MSG})")
+  else()
+    # If _CONSIDERED_CONFIGS is set, the config-file has been found, but no suitable version.
+    # List them all in the error message:
+    if(${_NAME}_CONSIDERED_CONFIGS)
+      set(configsText "")
+      list(LENGTH ${_NAME}_CONSIDERED_CONFIGS configsCount)
+      math(EXPR configsCount "${configsCount} - 1")
+      foreach(currentConfigIndex RANGE ${configsCount})
+        list(GET ${_NAME}_CONSIDERED_CONFIGS ${currentConfigIndex} filename)
+        list(GET ${_NAME}_CONSIDERED_VERSIONS ${currentConfigIndex} version)
+        string(APPEND configsText "\n    ${filename} (version ${version})")
+      endforeach()
+      if (${_NAME}_NOT_FOUND_MESSAGE)
+        if (FPHSA_REASON_FAILURE_MESSAGE)
+          string(PREPEND FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}\n    ")
+        else()
+          set(FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}")
+        endif()
+      else()
+        string(APPEND configsText "\n")
+      endif()
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} ${VERSION_MSG}, checked the following files:${configsText}")
+
+    else()
+      # Simple case: No Config-file was found at all:
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: found neither ${_NAME}Config.cmake nor ${_NAME_LOWER}-config.cmake ${VERSION_MSG}")
+    endif()
+  endif()
+endmacro()
+
+
+function(FIND_PACKAGE_CHECK_VERSION version result)
+  cmake_parse_arguments (PARSE_ARGV 2 FPCV "HANDLE_VERSION_RANGE;NO_AUTHOR_WARNING_VERSION_RANGE" "RESULT_MESSAGE_VARIABLE" "")
+
+  if (FPCV_UNPARSED_ARGUMENTS)
+    message (FATAL_ERROR "find_package_check_version(): ${FPCV_UNPARSED_ARGUMENTS}: unexpected arguments")
+  endif()
+  if ("RESULT_MESSAGE_VARIABLE" IN_LIST FPCV_KEYWORDS_MISSING_VALUES)
+    message (FATAL_ERROR "find_package_check_version(): RESULT_MESSAGE_VARIABLE expects an argument")
+  endif()
+
+  set (${result} FALSE PARENT_SCOPE)
+  if (FPCV_RESULT_MESSAGE_VARIABLE)
+    unset (${FPCV_RESULT_MESSAGE_VARIABLE} PARENT_SCOPE)
+  endif()
+
+  if (_CMAKE_FPHSA_PACKAGE_NAME)
+    set (package "${_CMAKE_FPHSA_PACKAGE_NAME}")
+  elseif (CMAKE_FIND_PACKAGE_NAME)
+    set (package "${CMAKE_FIND_PACKAGE_NAME}")
+  else()
+    message (FATAL_ERROR "find_package_check_version(): Cannot be used outside a 'Find Module'")
+  endif()
+
+  if (NOT FPCV_NO_AUTHOR_WARNING_VERSION_RANGE
+      AND ${package}_FIND_VERSION_RANGE AND NOT FPCV_HANDLE_VERSION_RANGE)
+    message(AUTHOR_WARNING
+      "`find_package()` specify a version range but the option "
+      "HANDLE_VERSION_RANGE` is not passed to `find_package_check_version()`. "
+      "Only the lower endpoint of the range will be used.")
+  endif()
+
+
+  set (version_ok FALSE)
+  unset (version_msg)
+
+  if (FPCV_HANDLE_VERSION_RANGE AND ${package}_FIND_VERSION_RANGE)
+    if ((${package}_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE"
+          AND version VERSION_GREATER_EQUAL ${package}_FIND_VERSION_MIN)
+        AND ((${package}_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE"
+            AND version VERSION_LESS_EQUAL ${package}_FIND_VERSION_MAX)
+          OR (${package}_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE"
+            AND version VERSION_LESS ${package}_FIND_VERSION_MAX)))
+      set (version_ok TRUE)
+      set(version_msg "(found suitable version \"${version}\", required range is \"${${package}_FIND_VERSION_RANGE}\")")
+    else()
+      set(version_msg "Found unsuitable version \"${version}\", required range is \"${${package}_FIND_VERSION_RANGE}\"")
+    endif()
+  elseif (DEFINED ${package}_FIND_VERSION)
+    if(${package}_FIND_VERSION_EXACT)       # exact version required
+      # count the dots in the version string
+      string(REGEX REPLACE "[^.]" "" version_dots "${version}")
+      # add one dot because there is one dot more than there are components
+      string(LENGTH "${version_dots}." version_dots)
+      if (version_dots GREATER ${package}_FIND_VERSION_COUNT)
+        # Because of the C++ implementation of find_package() ${package}_FIND_VERSION_COUNT
+        # is at most 4 here. Therefore a simple lookup table is used.
+        if (${package}_FIND_VERSION_COUNT EQUAL 1)
+          set(version_regex "[^.]*")
+        elseif (${package}_FIND_VERSION_COUNT EQUAL 2)
+          set(version_regex "[^.]*\\.[^.]*")
+        elseif (${package}_FIND_VERSION_COUNT EQUAL 3)
+          set(version_regex "[^.]*\\.[^.]*\\.[^.]*")
+        else()
+          set(version_regex "[^.]*\\.[^.]*\\.[^.]*\\.[^.]*")
+        endif()
+        string(REGEX REPLACE "^(${version_regex})\\..*" "\\1" version_head "${version}")
+        if (NOT ${package}_FIND_VERSION VERSION_EQUAL version_head)
+          set(version_msg "Found unsuitable version \"${version}\", but required is exact version \"${${package}_FIND_VERSION}\"")
+        else ()
+          set(version_ok TRUE)
+          set(version_msg "(found suitable exact version \"${version}\")")
+        endif ()
+      else ()
+        if (NOT ${package}_FIND_VERSION VERSION_EQUAL version)
+          set(version_msg "Found unsuitable version \"${version}\", but required is exact version \"${${package}_FIND_VERSION}\"")
+        else ()
+          set(version_ok TRUE)
+          set(version_msg "(found suitable exact version \"${version}\")")
+        endif ()
+      endif ()
+    else()     # minimum version
+      if (${package}_FIND_VERSION VERSION_GREATER version)
+        set(version_msg "Found unsuitable version \"${version}\", but required is at least \"${${package}_FIND_VERSION}\"")
+      else()
+        set(version_ok TRUE)
+        set(version_msg "(found suitable version \"${version}\", minimum required is \"${${package}_FIND_VERSION}\")")
+      endif()
+    endif()
+  else ()
+    set(version_ok TRUE)
+    set(version_msg "(found version \"${version}\")")
+  endif()
+
+  set (${result} ${version_ok} PARENT_SCOPE)
+  if (FPCV_RESULT_MESSAGE_VARIABLE)
+    set (${FPCV_RESULT_MESSAGE_VARIABLE} "${version_msg}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+
+function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
+
+  # Set up the arguments for `cmake_parse_arguments`.
+  set(options  CONFIG_MODE  HANDLE_COMPONENTS NAME_MISMATCHED HANDLE_VERSION_RANGE)
+  set(oneValueArgs  FAIL_MESSAGE  REASON_FAILURE_MESSAGE VERSION_VAR  FOUND_VAR)
+  set(multiValueArgs REQUIRED_VARS)
+
+  # Check whether we are in 'simple' or 'extended' mode:
+  set(_KEYWORDS_FOR_EXTENDED_MODE  ${options} ${oneValueArgs} ${multiValueArgs} )
+  list(FIND _KEYWORDS_FOR_EXTENDED_MODE "${_FIRST_ARG}" INDEX)
+
+  unset(FPHSA_NAME_MISMATCHED_override)
+  if (DEFINED FPHSA_NAME_MISMATCHED)
+    # If the variable NAME_MISMATCHED variable is set, error if it is passed as
+    # an argument. The former is for old signatures, the latter is for new
+    # signatures.
+    list(FIND ARGN "NAME_MISMATCHED" name_mismatched_idx)
+    if (NOT name_mismatched_idx EQUAL "-1")
+      message(FATAL_ERROR
+        "The `NAME_MISMATCHED` argument may only be specified by the argument or "
+        "the variable, not both.")
+    endif ()
+
+    # But use the variable if it is not an argument to avoid forcing minimum
+    # CMake version bumps for calling modules.
+    set(FPHSA_NAME_MISMATCHED_override "${FPHSA_NAME_MISMATCHED}")
+  endif ()
+
+  if(${INDEX} EQUAL -1)
+    set(FPHSA_FAIL_MESSAGE ${_FIRST_ARG})
+    set(FPHSA_REQUIRED_VARS ${ARGN})
+    set(FPHSA_VERSION_VAR)
+  else()
+    cmake_parse_arguments(FPHSA "${options}" "${oneValueArgs}" "${multiValueArgs}"  ${_FIRST_ARG} ${ARGN})
+
+    if(FPHSA_UNPARSED_ARGUMENTS)
+      message(FATAL_ERROR "Unknown keywords given to FIND_PACKAGE_HANDLE_STANDARD_ARGS(): \"${FPHSA_UNPARSED_ARGUMENTS}\"")
+    endif()
+
+    if(NOT FPHSA_FAIL_MESSAGE)
+      set(FPHSA_FAIL_MESSAGE  "DEFAULT_MSG")
+    endif()
+
+    # In config-mode, we rely on the variable <PackageName>_CONFIG, which is set by find_package()
+    # when it successfully found the config-file, including version checking:
+    if(FPHSA_CONFIG_MODE)
+      list(INSERT FPHSA_REQUIRED_VARS 0 ${_NAME}_CONFIG)
+      list(REMOVE_DUPLICATES FPHSA_REQUIRED_VARS)
+      set(FPHSA_VERSION_VAR ${_NAME}_VERSION)
+    endif()
+
+    if(NOT FPHSA_REQUIRED_VARS AND NOT FPHSA_HANDLE_COMPONENTS)
+      message(FATAL_ERROR "No REQUIRED_VARS specified for FIND_PACKAGE_HANDLE_STANDARD_ARGS()")
+    endif()
+  endif()
+
+  if (DEFINED FPHSA_NAME_MISMATCHED_override)
+    set(FPHSA_NAME_MISMATCHED "${FPHSA_NAME_MISMATCHED_override}")
+  endif ()
+
+  if (DEFINED CMAKE_FIND_PACKAGE_NAME
+      AND NOT FPHSA_NAME_MISMATCHED
+      AND NOT _NAME STREQUAL CMAKE_FIND_PACKAGE_NAME)
+    message(AUTHOR_WARNING
+      "The package name passed to `find_package_handle_standard_args` "
+      "(${_NAME}) does not match the name of the calling package "
+      "(${CMAKE_FIND_PACKAGE_NAME}). This can lead to problems in calling "
+      "code that expects `find_package` result variables (e.g., `_FOUND`) "
+      "to follow a certain pattern.")
+  endif ()
+
+  if (${_NAME}_FIND_VERSION_RANGE AND NOT FPHSA_HANDLE_VERSION_RANGE)
+    message(AUTHOR_WARNING
+      "`find_package()` specify a version range but the module ${_NAME} does "
+      "not support this capability. Only the lower endpoint of the range "
+      "will be used.")
+  endif()
+
+  # to propagate package name to FIND_PACKAGE_CHECK_VERSION
+  set(_CMAKE_FPHSA_PACKAGE_NAME "${_NAME}")
+
+  # now that we collected all arguments, process them
+
+  if("x${FPHSA_FAIL_MESSAGE}" STREQUAL "xDEFAULT_MSG")
+    set(FPHSA_FAIL_MESSAGE "Could NOT find ${_NAME}")
+  endif()
+
+  if (FPHSA_REQUIRED_VARS)
+    list(GET FPHSA_REQUIRED_VARS 0 _FIRST_REQUIRED_VAR)
+  endif()
+
+  string(TOUPPER ${_NAME} _NAME_UPPER)
+  string(TOLOWER ${_NAME} _NAME_LOWER)
+
+  if(FPHSA_FOUND_VAR)
+    set(_FOUND_VAR_UPPER ${_NAME_UPPER}_FOUND)
+    set(_FOUND_VAR_MIXED ${_NAME}_FOUND)
+    if(FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_MIXED  OR  FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_UPPER)
+      set(_FOUND_VAR ${FPHSA_FOUND_VAR})
+    else()
+      message(FATAL_ERROR "The argument for FOUND_VAR is \"${FPHSA_FOUND_VAR}\", but only \"${_FOUND_VAR_MIXED}\" and \"${_FOUND_VAR_UPPER}\" are valid names.")
+    endif()
+  else()
+    set(_FOUND_VAR ${_NAME_UPPER}_FOUND)
+  endif()
+
+  # collect all variables which were not found, so they can be printed, so the
+  # user knows better what went wrong (#6375)
+  set(MISSING_VARS "")
+  set(DETAILS "")
+  # check if all passed variables are valid
+  set(FPHSA_FOUND_${_NAME} TRUE)
+  foreach(_CURRENT_VAR ${FPHSA_REQUIRED_VARS})
+    if(NOT ${_CURRENT_VAR})
+      set(FPHSA_FOUND_${_NAME} FALSE)
+      string(APPEND MISSING_VARS " ${_CURRENT_VAR}")
+    else()
+      string(APPEND DETAILS "[${${_CURRENT_VAR}}]")
+    endif()
+  endforeach()
+  if(FPHSA_FOUND_${_NAME})
+    set(${_NAME}_FOUND TRUE)
+    set(${_NAME_UPPER}_FOUND TRUE)
+  else()
+    set(${_NAME}_FOUND FALSE)
+    set(${_NAME_UPPER}_FOUND FALSE)
+  endif()
+
+  # component handling
+  unset(FOUND_COMPONENTS_MSG)
+  unset(MISSING_COMPONENTS_MSG)
+
+  if(FPHSA_HANDLE_COMPONENTS)
+    foreach(comp ${${_NAME}_FIND_COMPONENTS})
+      if(${_NAME}_${comp}_FOUND)
+
+        if(NOT DEFINED FOUND_COMPONENTS_MSG)
+          set(FOUND_COMPONENTS_MSG "found components:")
+        endif()
+        string(APPEND FOUND_COMPONENTS_MSG " ${comp}")
+
+      else()
+
+        if(NOT DEFINED MISSING_COMPONENTS_MSG)
+          set(MISSING_COMPONENTS_MSG "missing components:")
+        endif()
+        string(APPEND MISSING_COMPONENTS_MSG " ${comp}")
+
+        if(${_NAME}_FIND_REQUIRED_${comp})
+          set(${_NAME}_FOUND FALSE)
+          string(APPEND MISSING_VARS " ${comp}")
+        endif()
+
+      endif()
+    endforeach()
+    set(COMPONENT_MSG "${FOUND_COMPONENTS_MSG} ${MISSING_COMPONENTS_MSG}")
+    string(APPEND DETAILS "[c${COMPONENT_MSG}]")
+  endif()
+
+  # version handling:
+  set(VERSION_MSG "")
+  set(VERSION_OK TRUE)
+
+  # check that the version variable is not empty to avoid emitting a misleading
+  # message (i.e. `Found unsuitable version ""`)
+  if (DEFINED ${_NAME}_FIND_VERSION)
+    if(DEFINED ${FPHSA_VERSION_VAR})
+      if(NOT "${${FPHSA_VERSION_VAR}}" STREQUAL "")
+        set(_FOUND_VERSION ${${FPHSA_VERSION_VAR}})
+        if (FPHSA_HANDLE_VERSION_RANGE)
+          set (FPCV_HANDLE_VERSION_RANGE HANDLE_VERSION_RANGE)
+        else()
+          set(FPCV_HANDLE_VERSION_RANGE NO_AUTHOR_WARNING_VERSION_RANGE)
+        endif()
+        find_package_check_version ("${_FOUND_VERSION}" VERSION_OK RESULT_MESSAGE_VARIABLE VERSION_MSG
+          ${FPCV_HANDLE_VERSION_RANGE})
+      else()
+        set(VERSION_OK FALSE)
+      endif()
+    endif()
+    if("${${FPHSA_VERSION_VAR}}" STREQUAL "")
+      # if the package was not found, but a version was given, add that to the output:
+      if(${_NAME}_FIND_VERSION_EXACT)
+        set(VERSION_MSG "(Required is exact version \"${${_NAME}_FIND_VERSION}\")")
+      elseif (FPHSA_HANDLE_VERSION_RANGE AND ${_NAME}_FIND_VERSION_RANGE)
+        set(VERSION_MSG "(Required is version range \"${${_NAME}_FIND_VERSION_RANGE}\")")
+      else()
+        set(VERSION_MSG "(Required is at least version \"${${_NAME}_FIND_VERSION}\")")
+      endif()
+    endif()
+  else ()
+    # Check with DEFINED as the found version may be 0.
+    if(DEFINED ${FPHSA_VERSION_VAR})
+      set(VERSION_MSG "(found version \"${${FPHSA_VERSION_VAR}}\")")
+    endif()
+  endif ()
+
+  if(VERSION_OK)
+    string(APPEND DETAILS "[v${${FPHSA_VERSION_VAR}}(${${_NAME}_FIND_VERSION})]")
+  else()
+    set(${_NAME}_FOUND FALSE)
+  endif()
+
+
+  # print the result:
+  if (${_NAME}_FOUND)
+    FIND_PACKAGE_MESSAGE(${_NAME} "Found ${_NAME}: ${${_FIRST_REQUIRED_VAR}} ${VERSION_MSG} ${COMPONENT_MSG}" "${DETAILS}")
+  else ()
+
+    if(FPHSA_CONFIG_MODE)
+      _FPHSA_HANDLE_FAILURE_CONFIG_MODE()
+    else()
+      if(NOT VERSION_OK)
+        set(RESULT_MSG)
+        if (_FIRST_REQUIRED_VAR)
+          string (APPEND RESULT_MSG "found ${${_FIRST_REQUIRED_VAR}}")
+        endif()
+        if (COMPONENT_MSG)
+          if (RESULT_MSG)
+            string (APPEND RESULT_MSG ", ")
+          endif()
+          string (APPEND RESULT_MSG "${FOUND_COMPONENTS_MSG}")
+        endif()
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: ${VERSION_MSG} (${RESULT_MSG})")
+      else()
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} (missing:${MISSING_VARS}) ${VERSION_MSG}")
+      endif()
+    endif()
+
+  endif ()
+
+  set(${_NAME}_FOUND ${${_NAME}_FOUND} PARENT_SCOPE)
+  set(${_NAME_UPPER}_FOUND ${${_NAME}_FOUND} PARENT_SCOPE)
+endfunction()
+
+
+cmake_policy(POP)

--- a/cmake/FindPackageMessage.cmake
+++ b/cmake/FindPackageMessage.cmake
@@ -1,0 +1,49 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindPackageMessage
+------------------
+
+.. code-block:: cmake
+
+  find_package_message(<name> "message for user" "find result details")
+
+This function is intended to be used in FindXXX.cmake modules files.
+It will print a message once for each unique find result.  This is
+useful for telling the user where a package was found.  The first
+argument specifies the name (XXX) of the package.  The second argument
+specifies the message to display.  The third argument lists details
+about the find result so that if they change the message will be
+displayed again.  The macro also obeys the QUIET argument to the
+find_package command.
+
+Example:
+
+.. code-block:: cmake
+
+  if(X11_FOUND)
+    find_package_message(X11 "Found X11: ${X11_X11_LIB}"
+      "[${X11_X11_LIB}][${X11_INCLUDE_DIR}]")
+  else()
+   ...
+  endif()
+#]=======================================================================]
+
+function(find_package_message pkg msg details)
+  # Avoid printing a message repeatedly for the same find result.
+  if(NOT ${pkg}_FIND_QUIETLY)
+    string(REPLACE "\n" "" details "${details}")
+    set(DETAILS_VAR FIND_PACKAGE_MESSAGE_DETAILS_${pkg})
+    if(NOT "${details}" STREQUAL "${${DETAILS_VAR}}")
+      # The message has not yet been printed.
+      string(STRIP "${msg}" msg)
+      message(STATUS "${msg}")
+
+      # Save the find details in the cache to avoid printing the same
+      # message again.
+      set("${DETAILS_VAR}" "${details}"
+        CACHE INTERNAL "Details about finding ${pkg}")
+    endif()
+  endif()
+endfunction()


### PR DESCRIPTION
Using FindBoost.cmake, FindPackageHandleStandardArgs.cmake and FindPackageMessage.cmake 
from cmake 3.30.4 to work with boost version 1.69.0